### PR TITLE
feat(storage): add FileObjectStore for durable local persistence

### DIFF
--- a/internal/storage/file_store.go
+++ b/internal/storage/file_store.go
@@ -1,0 +1,107 @@
+package storage
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// FileObjectStore is a file-backed ObjectStore. Each object key is mapped to a
+// file path under rootDir by treating forward-slash separators in keys as
+// directory separators. This matches the key layout produced by keys.go.
+//
+// Writes are performed atomically via a temp file and rename so that a process
+// crash during Put cannot leave a partially written file behind.
+//
+// FileObjectStore satisfies the ObjectStore interface and can be used anywhere
+// MemoryObjectStore is used today.
+type FileObjectStore struct {
+	rootDir string
+}
+
+// NewFileObjectStore returns a FileObjectStore rooted at rootDir. The directory
+// is created if it does not already exist.
+func NewFileObjectStore(rootDir string) (*FileObjectStore, error) {
+	if err := os.MkdirAll(rootDir, 0o700); err != nil {
+		return nil, err
+	}
+	return &FileObjectStore{rootDir: rootDir}, nil
+}
+
+func (s *FileObjectStore) filePath(key string) string {
+	return filepath.Join(s.rootDir, filepath.FromSlash(key))
+}
+
+// Put writes value to the file mapped to key. Parent directories are created as
+// needed. The write is atomic: a temp file is written first and then renamed
+// into place.
+func (s *FileObjectStore) Put(key string, value []byte) error {
+	p := s.filePath(key)
+
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return err
+	}
+
+	// Write to a sibling temp file then rename for atomicity.
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, value, 0o600); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp, p)
+}
+
+// Get reads the value stored under key. Returns ErrObjectNotFound if the key
+// does not exist.
+func (s *FileObjectStore) Get(key string) ([]byte, error) {
+	p := s.filePath(key)
+
+	data, err := os.ReadFile(p)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, ErrObjectNotFound(key)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// List returns all keys whose path begins with prefix, sorted lexicographically.
+// Temp files left by interrupted writes (suffix ".tmp") are excluded.
+func (s *FileObjectStore) List(prefix string) ([]string, error) {
+	var keys []string
+
+	err := filepath.WalkDir(s.rootDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Exclude in-flight temp files.
+		if strings.HasSuffix(p, ".tmp") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(s.rootDir, p)
+		if err != nil {
+			return err
+		}
+		key := filepath.ToSlash(rel)
+
+		if strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(keys)
+	return keys, nil
+}

--- a/internal/storage/file_store_test.go
+++ b/internal/storage/file_store_test.go
@@ -1,0 +1,309 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/ndelorme/safe/internal/domain"
+)
+
+// newTestFileStore creates a FileObjectStore rooted in a temp directory that is
+// cleaned up automatically when the test ends.
+func newTestFileStore(t *testing.T) *FileObjectStore {
+	t.Helper()
+	store, err := NewFileObjectStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileObjectStore: %v", err)
+	}
+	return store
+}
+
+// newTestFileStoreAt creates a FileObjectStore rooted at a specific directory.
+// Used by restart-survival tests that need two separate store instances backed
+// by the same directory.
+func newTestFileStoreAt(t *testing.T, dir string) *FileObjectStore {
+	t.Helper()
+	store, err := NewFileObjectStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileObjectStore(%s): %v", dir, err)
+	}
+	return store
+}
+
+func TestFileObjectStorePutGet(t *testing.T) {
+	store := newTestFileStore(t)
+
+	if err := store.Put("test-key", []byte("value")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, err := store.Get("test-key")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if string(got) != "value" {
+		t.Fatalf("unexpected value: %s", string(got))
+	}
+}
+
+func TestFileObjectStoreMissingKey(t *testing.T) {
+	store := newTestFileStore(t)
+
+	if _, err := store.Get("missing-key"); err == nil {
+		t.Fatal("expected missing key error")
+	}
+}
+
+func TestFileObjectStoreListByPrefix(t *testing.T) {
+	store := newTestFileStore(t)
+
+	if err := store.Put("accounts/a/collections/c/events/2.json", []byte("second")); err != nil {
+		t.Fatalf("put second: %v", err)
+	}
+	if err := store.Put("accounts/a/collections/c/events/1.json", []byte("first")); err != nil {
+		t.Fatalf("put first: %v", err)
+	}
+	if err := store.Put("accounts/a/collections/c/items/1.json", []byte("item")); err != nil {
+		t.Fatalf("put item: %v", err)
+	}
+
+	keys, err := store.List("accounts/a/collections/c/events/")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 event keys, got %d", len(keys))
+	}
+
+	if keys[0] != "accounts/a/collections/c/events/1.json" || keys[1] != "accounts/a/collections/c/events/2.json" {
+		t.Fatalf("unexpected keys: %+v", keys)
+	}
+}
+
+// TestFileObjectStoreRestartSurvival is the core acceptance test for W2.
+// It writes data through one FileObjectStore instance, creates a second
+// instance pointing at the same directory (simulating a process restart),
+// and verifies all records can still be read.
+func TestFileObjectStoreRestartSurvival(t *testing.T) {
+	dir := t.TempDir()
+
+	// --- process A: write ---
+	writer, err := NewFileObjectStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileObjectStore (writer): %v", err)
+	}
+
+	if err := writer.Put("accounts/acct1/account.json", []byte(`{"hello":"world"}`)); err != nil {
+		t.Fatalf("put account: %v", err)
+	}
+	if err := writer.Put("accounts/acct1/collections/col1/head.json", []byte(`{"head":true}`)); err != nil {
+		t.Fatalf("put head: %v", err)
+	}
+	if err := writer.Put("accounts/acct1/collections/col1/events/evt1.json", []byte(`{"seq":1}`)); err != nil {
+		t.Fatalf("put event: %v", err)
+	}
+	if err := writer.Put("accounts/acct1/collections/col1/secrets/ref1.txt", []byte("s3cr3t")); err != nil {
+		t.Fatalf("put secret: %v", err)
+	}
+
+	// --- process B: read (new instance, same dir) ---
+	reader := newTestFileStoreAt(t, dir)
+
+	account, err := reader.Get("accounts/acct1/account.json")
+	if err != nil {
+		t.Fatalf("get account after restart: %v", err)
+	}
+	if string(account) != `{"hello":"world"}` {
+		t.Fatalf("unexpected account: %s", account)
+	}
+
+	head, err := reader.Get("accounts/acct1/collections/col1/head.json")
+	if err != nil {
+		t.Fatalf("get head after restart: %v", err)
+	}
+	if string(head) != `{"head":true}` {
+		t.Fatalf("unexpected head: %s", head)
+	}
+
+	secret, err := reader.Get("accounts/acct1/collections/col1/secrets/ref1.txt")
+	if err != nil {
+		t.Fatalf("get secret after restart: %v", err)
+	}
+	if string(secret) != "s3cr3t" {
+		t.Fatalf("unexpected secret: %s", secret)
+	}
+
+	keys, err := reader.List("accounts/acct1/collections/col1/events/")
+	if err != nil {
+		t.Fatalf("list events after restart: %v", err)
+	}
+	if len(keys) != 1 || keys[0] != "accounts/acct1/collections/col1/events/evt1.json" {
+		t.Fatalf("unexpected event keys after restart: %v", keys)
+	}
+}
+
+// TestFileObjectStoreAccountConfigRestartSurvival tests the full
+// StoreAccountConfigRecord → restart → LoadAccountConfigRecord path.
+func TestFileObjectStoreAccountConfigRestartSurvival(t *testing.T) {
+	dir := t.TempDir()
+	record := domain.StarterAccountConfigRecord()
+
+	writer := newTestFileStoreAt(t, dir)
+	if _, err := StoreAccountConfigRecord(writer, record); err != nil {
+		t.Fatalf("store account config: %v", err)
+	}
+
+	reader := newTestFileStoreAt(t, dir)
+	loaded, err := LoadAccountConfigRecord(reader, record.AccountID)
+	if err != nil {
+		t.Fatalf("load account config after restart: %v", err)
+	}
+
+	if loaded.AccountID != record.AccountID {
+		t.Fatalf("account ID mismatch: want %s got %s", record.AccountID, loaded.AccountID)
+	}
+	if loaded.DefaultCollectionID != record.DefaultCollectionID {
+		t.Fatalf("default collection ID mismatch")
+	}
+	if len(loaded.DeviceIDs) != len(record.DeviceIDs) {
+		t.Fatalf("device IDs length mismatch")
+	}
+}
+
+// TestFileObjectStoreCollectionHeadRestartSurvival tests the
+// StoreCollectionHeadRecord → restart → LoadCollectionHeadRecord path.
+func TestFileObjectStoreCollectionHeadRestartSurvival(t *testing.T) {
+	dir := t.TempDir()
+	record := domain.StarterCollectionHeadRecord()
+
+	writer := newTestFileStoreAt(t, dir)
+	if _, err := StoreCollectionHeadRecord(writer, record); err != nil {
+		t.Fatalf("store collection head: %v", err)
+	}
+
+	reader := newTestFileStoreAt(t, dir)
+	loaded, err := LoadCollectionHeadRecord(reader, record.AccountID, record.CollectionID)
+	if err != nil {
+		t.Fatalf("load collection head after restart: %v", err)
+	}
+
+	if loaded.LatestEventID != record.LatestEventID {
+		t.Fatalf("latest event ID mismatch: want %s got %s", record.LatestEventID, loaded.LatestEventID)
+	}
+	if loaded.LatestSeq != record.LatestSeq {
+		t.Fatalf("latest seq mismatch")
+	}
+}
+
+// TestFileObjectStoreEventRecordsRestartSurvival tests that all event records
+// survive a restart and can be listed in order.
+func TestFileObjectStoreEventRecordsRestartSurvival(t *testing.T) {
+	dir := t.TempDir()
+	records := domain.StarterVaultEventRecords()
+
+	writer := newTestFileStoreAt(t, dir)
+	for _, r := range records {
+		if _, err := StoreEventRecord(writer, r); err != nil {
+			t.Fatalf("store event %s: %v", r.EventID, err)
+		}
+	}
+
+	reader := newTestFileStoreAt(t, dir)
+	loaded, err := LoadCollectionEventRecords(reader, records[0].AccountID, records[0].CollectionID)
+	if err != nil {
+		t.Fatalf("load event records after restart: %v", err)
+	}
+
+	if len(loaded) != len(records) {
+		t.Fatalf("expected %d event records, got %d", len(records), len(loaded))
+	}
+
+	for i, r := range records {
+		if loaded[i].EventID != r.EventID {
+			t.Fatalf("event[%d] ID mismatch: want %s got %s", i, r.EventID, loaded[i].EventID)
+		}
+		if loaded[i].Sequence != r.Sequence {
+			t.Fatalf("event[%d] sequence mismatch", i)
+		}
+	}
+}
+
+// TestFileObjectStoreSecretMaterialRestartSurvival tests that secret material
+// survives a restart.
+func TestFileObjectStoreSecretMaterialRestartSurvival(t *testing.T) {
+	dir := t.TempDir()
+
+	const (
+		accountID    = "acct-dev-001"
+		collectionID = "vault-personal"
+		secretRef    = "vault-secret://totp/gmail-primary"
+		secretValue  = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+	)
+
+	writer := newTestFileStoreAt(t, dir)
+	if _, err := StoreSecretMaterial(writer, accountID, collectionID, secretRef, secretValue); err != nil {
+		t.Fatalf("store secret material: %v", err)
+	}
+
+	reader := newTestFileStoreAt(t, dir)
+	loaded, err := LoadSecretMaterial(reader, accountID, collectionID, secretRef)
+	if err != nil {
+		t.Fatalf("load secret material after restart: %v", err)
+	}
+
+	if loaded != secretValue {
+		t.Fatalf("unexpected secret material: %s", loaded)
+	}
+}
+
+// TestFileObjectStoreItemRecordRestartSurvival tests that item records survive
+// a restart.
+func TestFileObjectStoreItemRecordRestartSurvival(t *testing.T) {
+	dir := t.TempDir()
+	record := domain.StarterVaultItemRecords()[0]
+
+	const (
+		accountID    = "acct-dev-001"
+		collectionID = "vault-personal"
+	)
+
+	writer := newTestFileStoreAt(t, dir)
+	if _, err := StoreItemRecord(writer, accountID, collectionID, record); err != nil {
+		t.Fatalf("store item record: %v", err)
+	}
+
+	reader := newTestFileStoreAt(t, dir)
+	loaded, err := LoadItemRecord(reader, accountID, collectionID, record.Item.ID)
+	if err != nil {
+		t.Fatalf("load item record after restart: %v", err)
+	}
+
+	if loaded.Item.ID != record.Item.ID {
+		t.Fatalf("item ID mismatch: want %s got %s", record.Item.ID, loaded.Item.ID)
+	}
+	if loaded.Item.Kind != record.Item.Kind {
+		t.Fatalf("item kind mismatch")
+	}
+}
+
+// TestFileObjectStorePutOverwrite verifies that a second Put replaces the
+// first value rather than appending to it.
+func TestFileObjectStorePutOverwrite(t *testing.T) {
+	store := newTestFileStore(t)
+
+	if err := store.Put("k", []byte("first")); err != nil {
+		t.Fatalf("first put: %v", err)
+	}
+	if err := store.Put("k", []byte("second")); err != nil {
+		t.Fatalf("second put: %v", err)
+	}
+
+	got, err := store.Get("k")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != "second" {
+		t.Fatalf("expected second, got %s", string(got))
+	}
+}


### PR DESCRIPTION
Implements W2 - Implement durable local persistence adapter.

Adds FileObjectStore to internal/storage/, satisfying the existing ObjectStore interface. Keys are mapped directly to file paths under a configurable root directory using the same slash-separated layout produced by keys.go (e.g. accounts/{id}/collections/{col}/events/{id}.json).

Writes use a temp-file + rename pattern so a crash during Put cannot leave partially written files. All higher-level store helpers (StoreAccountConfigRecord, StoreEventRecord, etc.) work unchanged against the new adapter because they target the ObjectStore interface.

Tests verify:
- basic Put/Get/List behaviour
- missing-key error
- overwrite semantics
- restart survival for all four persisted unit types: account config, collection head, event records, and secret material

Write scope: internal/storage/** only.