### PR TITLE
W2: Implement durable local persistence adapter

### DIFF
--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -197,6 +197,45 @@ func LoadSecretMaterial(store ObjectStore, accountID, collectionID, secretRef st
 	return string(payload), nil
 }
 
+// VaultMutation describes the records that must become durable together as
+// one logical vault mutation. HeadRecord and EventRecord are always required.
+// SecretRef and SecretMaterial are optional (both must be non-empty to write a
+// secret). ItemRecord is optional (nil means no item write).
+type VaultMutation struct {
+	AccountID      string
+	CollectionID   string
+	SecretRef      string
+	SecretMaterial string
+	ItemRecord     *domain.VaultItemRecord
+	EventRecord    domain.VaultEventRecord
+	HeadRecord     domain.CollectionHeadRecord
+}
+
+// CommitVaultMutation writes all records in m in dependency order: optional
+// secret material first, then optional item record, then event record, and
+// finally the collection head. Writing the head last ensures that a new head
+// is never observable before its supporting records are durable, even if the
+// process crashes mid-commit.
+func CommitVaultMutation(store ObjectStore, m VaultMutation) error {
+	if m.SecretRef != "" && m.SecretMaterial != "" {
+		if _, err := StoreSecretMaterial(store, m.AccountID, m.CollectionID, m.SecretRef, m.SecretMaterial); err != nil {
+			return err
+		}
+	}
+	if m.ItemRecord != nil {
+		if _, err := StoreItemRecord(store, m.AccountID, m.CollectionID, *m.ItemRecord); err != nil {
+			return err
+		}
+	}
+	if _, err := StoreEventRecord(store, m.EventRecord); err != nil {
+		return err
+	}
+	if _, err := StoreCollectionHeadRecord(store, m.HeadRecord); err != nil {
+		return err
+	}
+	return nil
+}
+
 type objectNotFoundError string
 
 func (key objectNotFoundError) Error() string {

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ndelorme/safe/internal/domain"
@@ -214,4 +215,159 @@ func TestStoreAndLoadSecretMaterial(t *testing.T) {
 	if loaded != "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ" {
 		t.Fatalf("unexpected loaded secret material: %s", loaded)
 	}
+}
+
+// TestCommitVaultMutationFull verifies that CommitVaultMutation writes all
+// records (secret, item, event, head) and that each can be read back.
+func TestCommitVaultMutationFull(t *testing.T) {
+	store := NewMemoryObjectStore()
+
+	events := domain.StarterVaultEventRecords()
+	items := domain.StarterVaultItemRecords()
+	itemRef := items[1]
+	event := events[1]
+	head := domain.CollectionHeadRecord{
+		SchemaVersion: 1,
+		AccountID:     event.AccountID,
+		CollectionID:  event.CollectionID,
+		LatestEventID: event.EventID,
+		LatestSeq:     event.Sequence,
+	}
+
+	const secretRef = "vault-secret://totp/gmail-primary"
+	const secretVal = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+	m := VaultMutation{
+		AccountID:      event.AccountID,
+		CollectionID:   event.CollectionID,
+		SecretRef:      secretRef,
+		SecretMaterial: secretVal,
+		ItemRecord:     &itemRef,
+		EventRecord:    event,
+		HeadRecord:     head,
+	}
+
+	if err := CommitVaultMutation(store, m); err != nil {
+		t.Fatalf("CommitVaultMutation: %v", err)
+	}
+
+	// secret survives
+	sec, err := LoadSecretMaterial(store, event.AccountID, event.CollectionID, secretRef)
+	if err != nil {
+		t.Fatalf("load secret: %v", err)
+	}
+	if sec != secretVal {
+		t.Fatalf("secret mismatch: got %s", sec)
+	}
+
+	// item survives
+	item, err := LoadItemRecord(store, event.AccountID, event.CollectionID, itemRef.Item.ID)
+	if err != nil {
+		t.Fatalf("load item: %v", err)
+	}
+	if item.Item.ID != itemRef.Item.ID {
+		t.Fatalf("item ID mismatch")
+	}
+
+	// event survives
+	evt, err := LoadEventRecord(store, event.AccountID, event.CollectionID, event.EventID)
+	if err != nil {
+		t.Fatalf("load event: %v", err)
+	}
+	if evt.EventID != event.EventID {
+		t.Fatalf("event ID mismatch")
+	}
+
+	// head is last, survives and matches
+	h, err := LoadCollectionHeadRecord(store, head.AccountID, head.CollectionID)
+	if err != nil {
+		t.Fatalf("load head: %v", err)
+	}
+	if h.LatestEventID != head.LatestEventID {
+		t.Fatalf("head event ID mismatch")
+	}
+}
+
+// TestCommitVaultMutationEventOnly verifies that CommitVaultMutation works
+// without an optional secret or item (the minimal delete-item path).
+func TestCommitVaultMutationEventOnly(t *testing.T) {
+	store := NewMemoryObjectStore()
+
+	events := domain.StarterVaultEventRecords()
+	event := events[0]
+	head := domain.CollectionHeadRecord{
+		SchemaVersion: 1,
+		AccountID:     event.AccountID,
+		CollectionID:  event.CollectionID,
+		LatestEventID: event.EventID,
+		LatestSeq:     event.Sequence,
+	}
+
+	m := VaultMutation{
+		AccountID:    event.AccountID,
+		CollectionID: event.CollectionID,
+		EventRecord:  event,
+		HeadRecord:   head,
+	}
+
+	if err := CommitVaultMutation(store, m); err != nil {
+		t.Fatalf("CommitVaultMutation: %v", err)
+	}
+
+	h, err := LoadCollectionHeadRecord(store, head.AccountID, head.CollectionID)
+	if err != nil {
+		t.Fatalf("load head: %v", err)
+	}
+	if h.LatestEventID != head.LatestEventID {
+		t.Fatalf("head event ID mismatch: got %s", h.LatestEventID)
+	}
+}
+
+// TestCommitVaultMutationHeadNotExposedBeforeEvent verifies the commit boundary
+// by using an errStore that fails on event writes: the head must not be visible
+// if the event write fails.
+func TestCommitVaultMutationHeadNotExposedBeforeEvent(t *testing.T) {
+	base := NewMemoryObjectStore()
+
+	events := domain.StarterVaultEventRecords()
+	event := events[0]
+	head := domain.CollectionHeadRecord{
+		SchemaVersion: 1,
+		AccountID:     event.AccountID,
+		CollectionID:  event.CollectionID,
+		LatestEventID: event.EventID,
+		LatestSeq:     event.Sequence,
+	}
+
+	failing := &failOnKeyStore{ObjectStore: base, failKey: EventObjectKey(event.AccountID, event.CollectionID, event.EventID)}
+
+	m := VaultMutation{
+		AccountID:    event.AccountID,
+		CollectionID: event.CollectionID,
+		EventRecord:  event,
+		HeadRecord:   head,
+	}
+
+	err := CommitVaultMutation(failing, m)
+	if err == nil {
+		t.Fatal("expected error from failing event write")
+	}
+
+	// head must not be readable because the event write failed first
+	if _, err := LoadCollectionHeadRecord(base, head.AccountID, head.CollectionID); err == nil {
+		t.Fatal("head must not be visible when event write failed")
+	}
+}
+
+// failOnKeyStore wraps an ObjectStore and returns an error for a specific key.
+type failOnKeyStore struct {
+	ObjectStore
+	failKey string
+}
+
+func (s *failOnKeyStore) Put(key string, value []byte) error {
+	if key == s.failKey {
+		return fmt.Errorf("injected failure for key %s", key)
+	}
+	return s.ObjectStore.Put(key, value)
 }


### PR DESCRIPTION
## Task

W2 - Implement durable local persistence adapter (refs #4)

**Owner:** Engineer2  
**Write scope:** `internal/storage/**`

## Changes

### `internal/storage/file_store.go` (new)
- `FileObjectStore` implementing `ObjectStore` (`Put`/`Get`/`List`)
- Keys map directly to file paths under a configurable root dir using the existing slash-separated key layout from `keys.go`
- Atomic writes via temp-file + `os.Rename` — no torn writes on crash
- `List` excludes `.tmp` files left by interrupted writes
- Directories created with `0700`, files with `0600`

### `internal/storage/store.go` (updated)
- `VaultMutation` type describing the records in one logical vault write
- `CommitVaultMutation` enforcing write order: secret → item → event → **head last** — satisfies I1 durable commit boundary (D6)

### Tests (24 total, all passing)
- Basic `Put`/`Get`/`List`, missing-key error, overwrite semantics
- Restart-survival tests for all five persisted units: account config, collection head, event records, item records, secret material
- `CommitVaultMutation` full path, event-only path, and head-not-exposed-on-event-failure

## Acceptance checks

- [x] Persists data across process recreation (new `FileObjectStore` instance, same dir)
- [x] No network or control-plane dependency
- [x] No implicit starter fixtures — `NewFileObjectStore` creates empty durable state only
- [x] Event records returned in deterministic ascending `sequence` order (sort in `LoadCollectionEventRecords`)
- [x] Durable commit boundary: head never observable before its supporting records (`CommitVaultMutation`)
- [x] Write scope stays within `internal/storage/**`
- [x] No changes to `cmd/safe/**`, `apps/web/**`, `packages/**`

## Dependencies

- W1 contract frozen (`docs/project/INTERFACES.md` I1) ✅

## Risks / open questions

- File-backed atomicity relies on `os.Rename` being atomic on the target OS/filesystem (true on Linux ext4/xfs; acceptable for M1)
- Encryption layering is deferred to W3 — `FileObjectStore` stores opaque bytes and does not assume plaintext

🤖 Generated with [Claude Code](https://claude.com/claude-code)