### PR TITLE
feat(crypto): add local unlock primitives

### DIFF
--- a/docs/project/DECISIONS.md
+++ b/docs/project/DECISIONS.md
@@ -192,23 +192,41 @@ Impact:
 
 ## Pending Decisions
 
-### P2 - Local encryption payload format
+### D7 - Local unlock uses an account-scoped Argon2id record plus AES-GCM envelopes
 
 Status:
 
-- pending
+- accepted
+
+Date:
+
+- 2026-04-04
 
 Owner:
 
 - Engineer1
 
-Question:
+Decision:
 
-- exact local envelope format for password-derived encryption, key wrapping, and versioning
+- W3 freezes the local unlock record at `accounts/<accountID>/unlock.json`
+- the password path derives a 32-byte KEK with Argon2id and unwraps a random 32-byte account master key with AES-256-GCM
+- encrypted secret material uses a versioned AES-256-GCM JSON envelope so the storage layer still treats it as opaque bytes
 
-Decision driver:
+Rationale:
 
-- must support wrong-password and corrupted-payload tests cleanly
+- W4 needs a stable unlock and secret-material format before wiring the CLI to durable local storage
+- the architecture docs already point at Argon2id and an account master key instead of deriving vault data keys directly from the password
+- a versioned JSON envelope is easy to inspect in tests while still keeping the storage contract backend-agnostic
+
+Impact:
+
+- `internal/crypto/**` is now the source of truth for local unlock and secret-material envelope parsing
+- `internal/storage/**` stores secret material as opaque bytes and persists the account-scoped unlock record without understanding the crypto payload
+- W4 should consume the frozen unlock record and envelope rather than introducing a second CLI-local format
+
+Refs:
+
+- `#5`
 
 ### P3 - Web local runtime storage boundary
 

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -115,3 +115,31 @@ Files:
 Next action:
 
 - implement the durable adapter and restart-survival tests against the frozen contract
+
+### 2026-04-04 - Engineer1 internal note
+
+Task:
+
+- `W3 - Add password-derived local encryption primitives`
+
+Status:
+
+- completed (`refs #5`)
+
+Files:
+
+- `internal/crypto/**`
+- `internal/domain/unlock.go`
+- `docs/project/INTERFACES.md`
+- `docs/project/DECISIONS.md`
+- `docs/project/WORKBOARD.md`
+
+Contract updates:
+
+- froze `accounts/<accountID>/unlock.json` as the account-scoped unlock metadata path
+- froze the `LocalUnlockRecord` Argon2id plus AES-256-GCM schema for password-derived account unlock
+- froze the versioned AES-256-GCM JSON envelope used for encrypted secret material
+
+Next action:
+
+- W4 can now wire `cmd/safe/**` to the durable adapter and real unlock flow without inventing new local crypto formats

--- a/docs/project/INTERFACES.md
+++ b/docs/project/INTERFACES.md
@@ -119,10 +119,23 @@ Required behaviors:
 - reject wrong password
 - reject corrupted ciphertext or metadata
 
-Not yet defined:
+Frozen for W3 (`refs #5`):
 
-- exact unlock record schema
-- exact crypto envelope
+- unlock metadata is stored at `accounts/<accountID>/unlock.json`
+- unlock record schema is `LocalUnlockRecord` with:
+  `schemaVersion`, `accountId`, `kdf`, and `wrappedKey`
+- `kdf` fields are:
+  `name=argon2id`, `salt`, `memoryKiB`, `timeCost`, `parallelism`, and `keyBytes`
+- `wrappedKey` fields are:
+  `algorithm=aes-256-gcm`, `nonce`, and `ciphertext`
+- the unlock flow derives a 32-byte KEK from the user password with Argon2id and unwraps a random 32-byte account master key via AES-256-GCM
+- local secret material is stored as a versioned JSON envelope containing:
+  `schemaVersion`, `algorithm`, `nonce`, and `ciphertext`
+- both the unlock record and the secret-material envelope use base64url encoding without padding for binary fields
+- wrong-password and corrupted-payload failures may share the same authentication-failure result; callers must reject both without exposing plaintext
+
+Still not defined:
+
 - password rotation flow
 - recovery-key support
 

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -178,7 +178,7 @@ Owner:
 
 Status:
 
-- ready
+- completed (`refs #5`)
 
 Write scope:
 
@@ -244,7 +244,7 @@ Owner:
 
 Status:
 
-- queued
+- ready
 
 Write scope:
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/ndelorme/safe
 
 go 1.23.0
+
+require golang.org/x/crypto v0.36.0
+
+require golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/internal/crypto/local_unlock.go
+++ b/internal/crypto/local_unlock.go
@@ -1,0 +1,251 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/argon2"
+
+	"github.com/ndelorme/safe/internal/domain"
+)
+
+const (
+	localUnlockSchemaVersion = 1
+	localUnlockAADPrefix     = "safe.local-unlock.v1/"
+	secretEnvelopeSchema     = 1
+	secretEnvelopeAAD        = "safe.secret-material.v1"
+
+	defaultArgonMemoryKiB   = 64 * 1024
+	defaultArgonTimeCost    = 3
+	defaultArgonParallelism = 4
+	defaultDerivedKeyBytes  = 32
+	accountMasterKeyBytes   = 32
+)
+
+var (
+	ErrUnlockFailed          = errors.New("local unlock authentication failed")
+	ErrSecretMaterialDecrypt = errors.New("secret material authentication failed")
+)
+
+type SecretMaterialEnvelope struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Algorithm     string `json:"algorithm"`
+	Nonce         string `json:"nonce"`
+	Ciphertext    string `json:"ciphertext"`
+}
+
+func CreateLocalUnlockRecord(accountID, password string) (domain.LocalUnlockRecord, []byte, error) {
+	return createLocalUnlockRecord(accountID, password, rand.Reader)
+}
+
+func OpenLocalUnlockRecord(record domain.LocalUnlockRecord, password string) ([]byte, error) {
+	if err := record.Validate(); err != nil {
+		return nil, err
+	}
+	if password == "" {
+		return nil, fmt.Errorf("password is required")
+	}
+
+	salt, err := decodeRaw(record.KDF.Salt)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := decodeRaw(record.WrappedKey.Nonce)
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := decodeRaw(record.WrappedKey.Ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	kek := deriveKey(password, salt, record.KDF)
+	plaintext, err := decryptBytes(kek, nonce, ciphertext, []byte(localUnlockAAD(record.AccountID)))
+	if err != nil {
+		return nil, ErrUnlockFailed
+	}
+
+	return plaintext, nil
+}
+
+func EncryptSecretMaterial(accountKey, plaintext []byte) ([]byte, error) {
+	return encryptSecretMaterial(accountKey, plaintext, rand.Reader)
+}
+
+func DecryptSecretMaterial(accountKey, payload []byte) ([]byte, error) {
+	if len(accountKey) != defaultDerivedKeyBytes {
+		return nil, fmt.Errorf("invalid account key length: %d", len(accountKey))
+	}
+
+	var envelope SecretMaterialEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, err
+	}
+	if err := envelope.Validate(); err != nil {
+		return nil, err
+	}
+
+	nonce, err := decodeRaw(envelope.Nonce)
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := decodeRaw(envelope.Ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := decryptBytes(accountKey, nonce, ciphertext, []byte(secretEnvelopeAAD))
+	if err != nil {
+		return nil, ErrSecretMaterialDecrypt
+	}
+
+	return plaintext, nil
+}
+
+func (envelope SecretMaterialEnvelope) Validate() error {
+	if envelope.SchemaVersion != secretEnvelopeSchema {
+		return fmt.Errorf("invalid secret material envelope schemaVersion: %d", envelope.SchemaVersion)
+	}
+	if envelope.Algorithm != "aes-256-gcm" {
+		return fmt.Errorf("invalid secret material envelope algorithm: %s", envelope.Algorithm)
+	}
+	if _, err := decodeRaw(envelope.Nonce); err != nil {
+		return fmt.Errorf("invalid secret material envelope nonce: %w", err)
+	}
+	if _, err := decodeRaw(envelope.Ciphertext); err != nil {
+		return fmt.Errorf("invalid secret material envelope ciphertext: %w", err)
+	}
+
+	return nil
+}
+
+func createLocalUnlockRecord(accountID, password string, random io.Reader) (domain.LocalUnlockRecord, []byte, error) {
+	if accountID == "" {
+		return domain.LocalUnlockRecord{}, nil, fmt.Errorf("accountID is required")
+	}
+	if password == "" {
+		return domain.LocalUnlockRecord{}, nil, fmt.Errorf("password is required")
+	}
+
+	salt, err := randomBytes(random, 16)
+	if err != nil {
+		return domain.LocalUnlockRecord{}, nil, err
+	}
+	accountKey, err := randomBytes(random, accountMasterKeyBytes)
+	if err != nil {
+		return domain.LocalUnlockRecord{}, nil, err
+	}
+
+	kdf := domain.LocalUnlockKDF{
+		Name:        "argon2id",
+		Salt:        encodeRaw(salt),
+		MemoryKiB:   defaultArgonMemoryKiB,
+		TimeCost:    defaultArgonTimeCost,
+		Parallelism: defaultArgonParallelism,
+		KeyBytes:    defaultDerivedKeyBytes,
+	}
+
+	kek := deriveKey(password, salt, kdf)
+	nonce, ciphertext, err := encryptBytes(kek, accountKey, []byte(localUnlockAAD(accountID)), random)
+	if err != nil {
+		return domain.LocalUnlockRecord{}, nil, err
+	}
+
+	record := domain.LocalUnlockRecord{
+		SchemaVersion: localUnlockSchemaVersion,
+		AccountID:     accountID,
+		KDF:           kdf,
+		WrappedKey: domain.LocalUnlockWrappedKey{
+			Algorithm:  "aes-256-gcm",
+			Nonce:      encodeRaw(nonce),
+			Ciphertext: encodeRaw(ciphertext),
+		},
+	}
+
+	return record, accountKey, nil
+}
+
+func encryptSecretMaterial(accountKey, plaintext []byte, random io.Reader) ([]byte, error) {
+	if len(accountKey) != defaultDerivedKeyBytes {
+		return nil, fmt.Errorf("invalid account key length: %d", len(accountKey))
+	}
+
+	nonce, ciphertext, err := encryptBytes(accountKey, plaintext, []byte(secretEnvelopeAAD), random)
+	if err != nil {
+		return nil, err
+	}
+
+	envelope := SecretMaterialEnvelope{
+		SchemaVersion: secretEnvelopeSchema,
+		Algorithm:     "aes-256-gcm",
+		Nonce:         encodeRaw(nonce),
+		Ciphertext:    encodeRaw(ciphertext),
+	}
+
+	if err := envelope.Validate(); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(envelope)
+}
+
+func deriveKey(password string, salt []byte, kdf domain.LocalUnlockKDF) []byte {
+	return argon2.IDKey([]byte(password), salt, uint32(kdf.TimeCost), uint32(kdf.MemoryKiB), uint8(kdf.Parallelism), uint32(kdf.KeyBytes))
+}
+
+func encryptBytes(key, plaintext, aad []byte, random io.Reader) ([]byte, []byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nonce, err := randomBytes(random, gcm.NonceSize())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nonce, gcm.Seal(nil, nonce, plaintext, aad), nil
+}
+
+func decryptBytes(key, nonce, ciphertext, aad []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	return gcm.Open(nil, nonce, ciphertext, aad)
+}
+
+func randomBytes(random io.Reader, size int) ([]byte, error) {
+	buf := make([]byte, size)
+	if _, err := io.ReadFull(random, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func encodeRaw(value []byte) string {
+	return base64.RawURLEncoding.EncodeToString(value)
+}
+
+func decodeRaw(value string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(value)
+}
+
+func localUnlockAAD(accountID string) string {
+	return localUnlockAADPrefix + accountID
+}

--- a/internal/crypto/local_unlock_test.go
+++ b/internal/crypto/local_unlock_test.go
@@ -1,0 +1,111 @@
+package crypto
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestCreateAndOpenLocalUnlockRecord(t *testing.T) {
+	record, accountKey, err := CreateLocalUnlockRecord("acct-dev-001", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("create local unlock record: %v", err)
+	}
+
+	reopenedKey, err := OpenLocalUnlockRecord(record, "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("open local unlock record: %v", err)
+	}
+
+	if string(reopenedKey) != string(accountKey) {
+		t.Fatal("expected reopened account key to match created key")
+	}
+}
+
+func TestOpenLocalUnlockRecordRejectsWrongPassword(t *testing.T) {
+	record, _, err := CreateLocalUnlockRecord("acct-dev-001", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("create local unlock record: %v", err)
+	}
+
+	_, err = OpenLocalUnlockRecord(record, "wrong password")
+	if !errors.Is(err, ErrUnlockFailed) {
+		t.Fatalf("expected ErrUnlockFailed, got %v", err)
+	}
+}
+
+func TestOpenLocalUnlockRecordRejectsCorruptedPayload(t *testing.T) {
+	record, _, err := CreateLocalUnlockRecord("acct-dev-001", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("create local unlock record: %v", err)
+	}
+
+	record.WrappedKey.Ciphertext = record.WrappedKey.Ciphertext[:len(record.WrappedKey.Ciphertext)-2] + "xx"
+
+	_, err = OpenLocalUnlockRecord(record, "correct horse battery staple")
+	if !errors.Is(err, ErrUnlockFailed) {
+		t.Fatalf("expected ErrUnlockFailed, got %v", err)
+	}
+}
+
+func TestEncryptAndDecryptSecretMaterial(t *testing.T) {
+	_, accountKey, err := CreateLocalUnlockRecord("acct-dev-001", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("create local unlock record: %v", err)
+	}
+
+	payload, err := EncryptSecretMaterial(accountKey, []byte("vault-secret-value"))
+	if err != nil {
+		t.Fatalf("encrypt secret material: %v", err)
+	}
+
+	plaintext, err := DecryptSecretMaterial(accountKey, payload)
+	if err != nil {
+		t.Fatalf("decrypt secret material: %v", err)
+	}
+
+	if string(plaintext) != "vault-secret-value" {
+		t.Fatalf("unexpected plaintext: %s", plaintext)
+	}
+}
+
+func TestDecryptSecretMaterialRejectsCorruptedPayload(t *testing.T) {
+	_, accountKey, err := CreateLocalUnlockRecord("acct-dev-001", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("create local unlock record: %v", err)
+	}
+
+	payload, err := EncryptSecretMaterial(accountKey, []byte("vault-secret-value"))
+	if err != nil {
+		t.Fatalf("encrypt secret material: %v", err)
+	}
+
+	var envelope SecretMaterialEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatalf("unmarshal secret material envelope: %v", err)
+	}
+	envelope.Ciphertext = envelope.Ciphertext[:len(envelope.Ciphertext)-2] + "xx"
+
+	corruptedPayload, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal corrupted secret material envelope: %v", err)
+	}
+
+	_, err = DecryptSecretMaterial(accountKey, corruptedPayload)
+	if !errors.Is(err, ErrSecretMaterialDecrypt) {
+		t.Fatalf("expected ErrSecretMaterialDecrypt, got %v", err)
+	}
+}
+
+func TestSecretMaterialEnvelopeValidateRejectsInvalidShape(t *testing.T) {
+	envelope := SecretMaterialEnvelope{
+		SchemaVersion: 1,
+		Algorithm:     "aes-256-gcm",
+		Nonce:         "bad-base64***",
+		Ciphertext:    "still-bad***",
+	}
+
+	if err := envelope.Validate(); err == nil {
+		t.Fatal("expected invalid secret material envelope")
+	}
+}

--- a/internal/domain/unlock.go
+++ b/internal/domain/unlock.go
@@ -1,0 +1,118 @@
+package domain
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+type LocalUnlockKDF struct {
+	Name        string `json:"name"`
+	Salt        string `json:"salt"`
+	MemoryKiB   int    `json:"memoryKiB"`
+	TimeCost    int    `json:"timeCost"`
+	Parallelism int    `json:"parallelism"`
+	KeyBytes    int    `json:"keyBytes"`
+}
+
+type LocalUnlockWrappedKey struct {
+	Algorithm  string `json:"algorithm"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type LocalUnlockRecord struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	AccountID     string                `json:"accountId"`
+	KDF           LocalUnlockKDF        `json:"kdf"`
+	WrappedKey    LocalUnlockWrappedKey `json:"wrappedKey"`
+}
+
+func (record LocalUnlockRecord) Validate() error {
+	if record.SchemaVersion != 1 {
+		return ErrInvalidLocalUnlockRecord("schemaVersion")
+	}
+	if record.AccountID == "" {
+		return ErrInvalidLocalUnlockRecord("accountId")
+	}
+	if record.KDF.Name != "argon2id" {
+		return ErrInvalidLocalUnlockRecord("kdf.name")
+	}
+	if !isValidRawBase64(record.KDF.Salt) {
+		return ErrInvalidLocalUnlockRecord("kdf.salt")
+	}
+	if record.KDF.MemoryKiB < 1 {
+		return ErrInvalidLocalUnlockRecord("kdf.memoryKiB")
+	}
+	if record.KDF.TimeCost < 1 {
+		return ErrInvalidLocalUnlockRecord("kdf.timeCost")
+	}
+	if record.KDF.Parallelism < 1 || record.KDF.Parallelism > 255 {
+		return ErrInvalidLocalUnlockRecord("kdf.parallelism")
+	}
+	if record.KDF.KeyBytes != 32 {
+		return ErrInvalidLocalUnlockRecord("kdf.keyBytes")
+	}
+	if record.WrappedKey.Algorithm != "aes-256-gcm" {
+		return ErrInvalidLocalUnlockRecord("wrappedKey.algorithm")
+	}
+	if !isValidRawBase64(record.WrappedKey.Nonce) {
+		return ErrInvalidLocalUnlockRecord("wrappedKey.nonce")
+	}
+	if !isValidRawBase64(record.WrappedKey.Ciphertext) {
+		return ErrInvalidLocalUnlockRecord("wrappedKey.ciphertext")
+	}
+
+	return nil
+}
+
+func (record LocalUnlockRecord) CanonicalJSON() ([]byte, error) {
+	if err := record.Validate(); err != nil {
+		return nil, err
+	}
+
+	type canonicalLocalUnlockRecord struct {
+		SchemaVersion int                   `json:"schemaVersion"`
+		AccountID     string                `json:"accountId"`
+		KDF           LocalUnlockKDF        `json:"kdf"`
+		WrappedKey    LocalUnlockWrappedKey `json:"wrappedKey"`
+	}
+
+	return json.Marshal(canonicalLocalUnlockRecord{
+		SchemaVersion: record.SchemaVersion,
+		AccountID:     record.AccountID,
+		KDF:           record.KDF,
+		WrappedKey:    record.WrappedKey,
+	})
+}
+
+func ParseLocalUnlockRecordJSON(data []byte) (LocalUnlockRecord, error) {
+	var record LocalUnlockRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return LocalUnlockRecord{}, err
+	}
+
+	if err := record.Validate(); err != nil {
+		return LocalUnlockRecord{}, err
+	}
+
+	return record, nil
+}
+
+type invalidLocalUnlockRecordError string
+
+func (field invalidLocalUnlockRecordError) Error() string {
+	return "invalid local unlock record field: " + string(field)
+}
+
+func ErrInvalidLocalUnlockRecord(field string) error {
+	return invalidLocalUnlockRecordError(field)
+}
+
+func isValidRawBase64(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	_, err := base64.RawURLEncoding.DecodeString(value)
+	return err == nil
+}

--- a/internal/domain/unlock_test.go
+++ b/internal/domain/unlock_test.go
@@ -1,0 +1,74 @@
+package domain
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func TestLocalUnlockRecordCanonicalSerialization(t *testing.T) {
+	record := LocalUnlockRecord{
+		SchemaVersion: 1,
+		AccountID:     "acct-dev-001",
+		KDF: LocalUnlockKDF{
+			Name:        "argon2id",
+			Salt:        base64.RawURLEncoding.EncodeToString([]byte("0123456789abcdef")),
+			MemoryKiB:   65536,
+			TimeCost:    3,
+			Parallelism: 4,
+			KeyBytes:    32,
+		},
+		WrappedKey: LocalUnlockWrappedKey{
+			Algorithm:  "aes-256-gcm",
+			Nonce:      base64.RawURLEncoding.EncodeToString([]byte("0123456789ab")),
+			Ciphertext: base64.RawURLEncoding.EncodeToString([]byte("ciphertext")),
+		},
+	}
+
+	canonical, err := record.CanonicalJSON()
+	if err != nil {
+		t.Fatalf("canonicalize local unlock record: %v", err)
+	}
+
+	expected, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal expected local unlock record: %v", err)
+	}
+
+	if string(canonical) != string(expected) {
+		t.Fatalf("local unlock canonical mismatch\nexpected: %s\ngot: %s", string(expected), string(canonical))
+	}
+
+	parsed, err := ParseLocalUnlockRecordJSON(canonical)
+	if err != nil {
+		t.Fatalf("parse local unlock record: %v", err)
+	}
+
+	if parsed.AccountID != record.AccountID || parsed.KDF.Name != "argon2id" {
+		t.Fatalf("unexpected parsed local unlock record: %+v", parsed)
+	}
+}
+
+func TestLocalUnlockRecordValidateRejectsInvalidFields(t *testing.T) {
+	record := LocalUnlockRecord{
+		SchemaVersion: 1,
+		AccountID:     "acct-dev-001",
+		KDF: LocalUnlockKDF{
+			Name:        "argon2id",
+			Salt:        "not-base64***",
+			MemoryKiB:   65536,
+			TimeCost:    3,
+			Parallelism: 4,
+			KeyBytes:    32,
+		},
+		WrappedKey: LocalUnlockWrappedKey{
+			Algorithm:  "aes-256-gcm",
+			Nonce:      base64.RawURLEncoding.EncodeToString([]byte("0123456789ab")),
+			Ciphertext: base64.RawURLEncoding.EncodeToString([]byte("ciphertext")),
+		},
+	}
+
+	if err := record.Validate(); err == nil {
+		t.Fatal("expected invalid local unlock record error")
+	}
+}

--- a/internal/storage/keys.go
+++ b/internal/storage/keys.go
@@ -29,6 +29,10 @@ func AccountConfigKey(accountID string) string {
 	return fmt.Sprintf("accounts/%s/account.json", accountID)
 }
 
+func LocalUnlockKey(accountID string) string {
+	return fmt.Sprintf("accounts/%s/unlock.json", accountID)
+}
+
 func SecretMaterialKey(accountID, collectionID, secretRef string) string {
 	encodedRef := base64.RawURLEncoding.EncodeToString([]byte(secretRef))
 	return fmt.Sprintf("accounts/%s/collections/%s/secrets/%s.txt", accountID, collectionID, encodedRef)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -130,6 +130,14 @@ func LoadCollectionEventRecords(store ObjectStore, accountID, collectionID strin
 		records = append(records, record)
 	}
 
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Sequence == records[j].Sequence {
+			return records[i].EventID < records[j].EventID
+		}
+
+		return records[i].Sequence < records[j].Sequence
+	})
+
 	return records, nil
 }
 
@@ -179,17 +187,48 @@ func LoadAccountConfigRecord(store ObjectStore, accountID string) (domain.Accoun
 	return domain.ParseAccountConfigRecordJSON(payload)
 }
 
-func StoreSecretMaterial(store ObjectStore, accountID, collectionID, secretRef, secret string) (string, error) {
-	key := SecretMaterialKey(accountID, collectionID, secretRef)
-	if err := store.Put(key, []byte(secret)); err != nil {
+func StoreLocalUnlockRecord(store ObjectStore, record domain.LocalUnlockRecord) (string, error) {
+	payload, err := record.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+
+	key := LocalUnlockKey(record.AccountID)
+	if err := store.Put(key, payload); err != nil {
 		return "", err
 	}
 
 	return key, nil
 }
 
+func LoadLocalUnlockRecord(store ObjectStore, accountID string) (domain.LocalUnlockRecord, error) {
+	payload, err := store.Get(LocalUnlockKey(accountID))
+	if err != nil {
+		return domain.LocalUnlockRecord{}, err
+	}
+
+	return domain.ParseLocalUnlockRecordJSON(payload)
+}
+
+func StoreSecretMaterialBytes(store ObjectStore, accountID, collectionID, secretRef string, secret []byte) (string, error) {
+	key := SecretMaterialKey(accountID, collectionID, secretRef)
+	if err := store.Put(key, secret); err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func LoadSecretMaterialBytes(store ObjectStore, accountID, collectionID, secretRef string) ([]byte, error) {
+	return store.Get(SecretMaterialKey(accountID, collectionID, secretRef))
+}
+
+func StoreSecretMaterial(store ObjectStore, accountID, collectionID, secretRef, secret string) (string, error) {
+	return StoreSecretMaterialBytes(store, accountID, collectionID, secretRef, []byte(secret))
+}
+
 func LoadSecretMaterial(store ObjectStore, accountID, collectionID, secretRef string) (string, error) {
-	payload, err := store.Get(SecretMaterialKey(accountID, collectionID, secretRef))
+	payload, err := LoadSecretMaterialBytes(store, accountID, collectionID, secretRef)
 	if err != nil {
 		return "", err
 	}

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -148,6 +148,49 @@ func TestLoadCollectionEventRecords(t *testing.T) {
 	}
 }
 
+func TestLoadCollectionEventRecordsSortsBySequence(t *testing.T) {
+	store := NewMemoryObjectStore()
+	records := []domain.VaultEventRecord{
+		{
+			SchemaVersion: 1,
+			EventID:       "evt-seq-2",
+			AccountID:     "acct-dev-001",
+			DeviceID:      "dev-web-001",
+			CollectionID:  "vault-personal",
+			Sequence:      2,
+			OccurredAt:    "2026-03-31T10:01:00Z",
+			Action:        domain.VaultEventActionPutItem,
+			ItemRecord:    domain.StarterVaultItemRecords()[0],
+		},
+		{
+			SchemaVersion: 1,
+			EventID:       "evt-seq-1",
+			AccountID:     "acct-dev-001",
+			DeviceID:      "dev-web-001",
+			CollectionID:  "vault-personal",
+			Sequence:      1,
+			OccurredAt:    "2026-03-31T10:00:00Z",
+			Action:        domain.VaultEventActionPutItem,
+			ItemRecord:    domain.StarterVaultItemRecords()[1],
+		},
+	}
+
+	for _, record := range records {
+		if _, err := StoreEventRecord(store, record); err != nil {
+			t.Fatalf("store event record: %v", err)
+		}
+	}
+
+	loaded, err := LoadCollectionEventRecords(store, "acct-dev-001", "vault-personal")
+	if err != nil {
+		t.Fatalf("load collection event records: %v", err)
+	}
+
+	if loaded[0].Sequence != 1 || loaded[1].Sequence != 2 {
+		t.Fatalf("expected sequence order, got %+v", loaded)
+	}
+}
+
 func TestStoreAndLoadCollectionHeadRecord(t *testing.T) {
 	store := NewMemoryObjectStore()
 	record := domain.StarterCollectionHeadRecord()


### PR DESCRIPTION
Refs #5
Milestone: M1 - First Trustworthy Local Loop

## Summary
- add the account-scoped `LocalUnlockRecord` contract and storage key
- add Argon2id + AES-256-GCM local unlock helpers and a versioned secret-material envelope
- add byte-safe secret storage helpers and enforce collection event replay ordering by `sequence`
- freeze the W3 contract in repo docs and mark W4 ready

## Verification
- `go test ./...`