### PR TITLE
docs: add M1 closeout planning (W6/W7), decision D8, and GitHub labeling guidance

### DIFF
--- a/docs/project/DECISIONS.md
+++ b/docs/project/DECISIONS.md
@@ -228,6 +228,43 @@ Refs:
 
 - `#5`
 
+### D8 - Post-M1 planning uses explicit stabilization plus UX backlog slices
+
+Status:
+
+- accepted
+
+Date:
+
+- 2026-04-05
+
+Owner:
+
+- Engineer1
+
+Decision:
+
+- once W1-W5 are complete, the next planning step is split into:
+  - W6: milestone closeout audit and release checklist
+  - W7: post-M1 UX and reliability backlog definition with consistent issue tagging
+- W6 and W7 should be tracked as dedicated issues after bootstrap under milestone issue `#1`
+
+Rationale:
+
+- the team needs clear separation between “verify what is done” and “define what comes next”
+- two-engineer execution (Codex plus Claude) works best when one engineer handles closeout correctness while the other prepares backlog quality
+- a normalized label taxonomy lowers future planning ambiguity and keeps the project board sortable
+
+Impact:
+
+- milestone-close communication should reference W6 and W7 explicitly instead of reopening completed W1-W5 issues
+- new backlog issues should include `area/*`, `type/*`, and `priority/*` labels before being added to the project board
+- PM should treat issue or project status drift as a blocking planning bug during closeout
+
+Refs:
+
+- `#1`
+
 ## Open Questions
 
 ### P3 - Web local runtime storage boundary

--- a/docs/project/GITHUB_PROJECTS.md
+++ b/docs/project/GITHUB_PROJECTS.md
@@ -124,6 +124,26 @@ Reopen an issue:
 gh issue reopen <number> --repo cyber-nic/safe
 ```
 
+Add labels while creating or editing planning issues:
+
+```bash
+gh issue create --repo cyber-nic/safe \
+  --title "W6: M1 closeout audit and release checklist" \
+  --body "..." \
+  --label "area/planning" \
+  --label "type/task" \
+  --label "priority/p0"
+
+gh issue edit <number> --repo cyber-nic/safe \
+  --add-label "area/web,priority/p1"
+```
+
+Recommended planning label taxonomy:
+
+- `area/planning`, `area/runtime`, `area/cli`, `area/web`, `area/storage`, `area/crypto`
+- `type/task`, `type/bug`, `type/follow-up`, `type/risk`
+- `priority/p0`, `priority/p1`, `priority/p2`
+
 ## Working With The Project
 
 List items:

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -34,6 +34,53 @@ Current planning issues:
 
 ## Entries
 
+### 2026-04-05 - Engineer1 to Engineer1
+
+Task:
+
+- `W6 - M1 closeout audit and release checklist`
+
+Status:
+
+- assigned (`refs #1`)
+
+Write scope:
+
+- `docs/project/WORKBOARD.md`
+- `docs/project/HANDOFFS.md`
+- `docs/project/DECISIONS.md`
+- release-readiness notes in `docs/architecture/IMPLEMENTATION_PLAN.md` only
+
+Next action:
+
+- reconcile milestone docs against GitHub issue and project statuses, then produce a closeout checklist and identified follow-up issue set
+
+### 2026-04-05 - Engineer1 to Engineer2
+
+Task:
+
+- `W7 - Post-M1 UX and reliability backlog definition`
+
+Status:
+
+- planned; pending assignment acceptance (`refs #1`)
+
+Write scope:
+
+- GitHub planning issues and labels
+- summary note in `docs/project/HANDOFFS.md`
+
+Do not edit:
+
+- `cmd/safe/**`
+- `apps/web/**`
+- `internal/storage/**`
+- `internal/crypto/**`
+
+Next action:
+
+- draft and tag post-M1 backlog issues (`area/*`, `type/*`, `priority/*`) after W6 publishes the closeout checklist
+
 ### 2026-04-04 - Engineer1 to Engineer2
 
 Task:

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -50,6 +50,11 @@ Non-goals for this milestone:
 - OAuth production hardening
 - rich vault UX beyond what is needed to prove the loop
 
+Milestone closeout status:
+
+- technical implementation slices W1-W5 are complete (`refs #2`, `#3`, `#4`, `#5`, `#6`)
+- remaining PM work is planning hygiene: verify issue states, project statuses, and define the first post-M1 queue (`refs #1`)
+
 ## Execution Rules
 
 - Work from the critical path outward, not from surface area inward.
@@ -295,12 +300,75 @@ GitHub issue:
 
 ## Next Assignment
 
-No new slice is assigned yet.
+M1 closeout planning is now active under milestone issue `#1`.
 
 Current focus:
 
 - close out `M1 - First Trustworthy Local Loop`
-- capture any post-W5 polish as explicit follow-up work instead of reopening completed milestone tasks
+- capture post-W5 polish as explicit follow-up work instead of reopening completed milestone tasks
+- split next execution into one stabilization slice and one product-surface slice so Codex and Claude can run in parallel after PM sign-off
+
+Planned next slices (`refs #1`; create dedicated issues before coding):
+
+### W6 - M1 closeout audit and release checklist
+
+Owner:
+
+- Engineer1 (Codex)
+
+Status:
+
+- planned
+
+Write scope:
+
+- `docs/project/WORKBOARD.md`
+- `docs/project/HANDOFFS.md`
+- `docs/project/DECISIONS.md`
+- release-readiness notes in `docs/architecture/IMPLEMENTATION_PLAN.md` only
+
+Output:
+
+- audited mapping between docs, issue states, and project board status values
+- explicit release checklist for the first trustworthy local loop (lock or unlock, restart readback, known failure modes)
+- list of any missing follow-up issues required before milestone close
+
+Dependencies:
+
+- W1-W5 complete
+
+GitHub issue:
+
+- `#1` (dedicated W6 issue to be created)
+
+### W7 - Post-M1 UX and reliability backlog definition
+
+Owner:
+
+- Engineer2 (Claude)
+
+Status:
+
+- planned
+
+Write scope:
+
+- issue drafts and labels in GitHub only
+- summary sync in `docs/project/HANDOFFS.md`
+
+Output:
+
+- prioritized backlog proposals grouped by severity (`must-fix`, `should-fix`, `nice-to-have`)
+- issue labels normalized for planning visibility (`area/*`, `type/*`, `priority/*`)
+- project-ready candidate slices with acceptance criteria and dependency notes
+
+Dependencies:
+
+- W6 closeout checklist draft
+
+GitHub issue:
+
+- `#1` (dedicated W7 issue to be created)
 
 ## Merge Order
 


### PR DESCRIPTION
### Motivation

- W1–W5 implementation slices are complete and the repo needs an explicit milestone closeout and follow-up planning step to avoid reopening finished tasks. 
- Separate verification (stabilization/closeout) from backlog definition so two engineers can run parallel planning workflows. 
- Normalize issue labeling and GitHub guidance to keep project-board triage consistent when creating follow-up work.

### Description

- Updated `docs/project/WORKBOARD.md` to mark W1–W5 as complete, add a "Milestone closeout status" section, and introduce planned slices `W6` (M1 closeout audit) and `W7` (post-M1 UX and reliability backlog) with owners, write scopes, outputs, dependencies, and linkage to milestone issue `#1`.
- Appended handoff entries to `docs/project/HANDOFFS.md` that assign `W6` to Engineer1 (Codex) and stage `W7` for Engineer2 (Claude) with next actions and do-not-edit constraints.
- Added decision `D8` to `docs/project/DECISIONS.md` to formalize the split between closeout and backlog-definition slices and require consistent labeling and tracking under `#1`.
- Extended `docs/project/GITHUB_PROJECTS.md` with concrete `gh` examples for adding labels on planning issues and a recommended planning label taxonomy (`area/*`, `type/*`, `priority/*`).

### Testing

- Ran `git diff --check` to validate whitespace and patch sanity, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22824f148832da9ed648d6cf7fead)