### PR TITLE
docs(plan): record M1 milestone reality (W6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,20 @@ Useful progress already landed:
 - a script-friendly CLI prototype for local secret CRUD, history, import/export, and JSON output
 - durable file-backed local runtime wiring in the CLI, including password-derived unlock and encrypted secret-material storage
 - web local runtime persistence aligned around account config, optional head state, replayable events, and locked-at-rest secret handling
+- full Go test coverage for the current local-runtime path passes on `main`
 
 But the project is still behind the plan's actual critical path:
 
+- there is still no navigable authenticated client surface for the first trustworthy save or read loop
 - cryptographic key hierarchy and recovery flows are still missing
 - signed mutable metadata and rollback detection are still missing
 - object-store sync is still a starter model, not the intended v1 storage protocol
 
 ## Immediate Next Steps
 
-1. Finish the first real user loop in a client surface: sign in, save a secret, and read it back.
-2. Validate the M1 local-runtime loop end to end across the shipped CLI and web surfaces.
-3. Pull the next milestone boundary forward only after any remaining M1 polish is explicit and scoped.
+1. Deliver a real client surface for the M1 save or read loop instead of relying on runtime packages and tests alone.
+2. Close M1 only after that client can identify, save, lock or reload, and read the same secret back.
+3. Pull the next milestone boundary forward only after the remaining critical-path gaps are explicit and scoped.
 4. Continue signer, rollback, and sync-hardening work only insofar as it supports that first trustworthy save/read loop, then expand outward.
 
 ## Local Development

--- a/docs/project/DECISIONS.md
+++ b/docs/project/DECISIONS.md
@@ -76,6 +76,7 @@ Impact:
 
 - new work must justify itself against the local-runtime milestone
 - non-critical surface expansion should be deferred
+- runtime helper packages do not count as milestone completion unless they are exposed through a real client surface
 
 ### D3 - Ownership is directory-first
 

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -31,6 +31,11 @@ Current planning issues:
 - `#5` W3
 - `#3` W4
 - `#2` W5
+- `#21` W6
+- `#22` W10
+- `#20` W7
+- `#19` W8
+- `#18` W9
 
 ## Entries
 
@@ -252,3 +257,37 @@ Files touched:
 Next action:
 
 - M1 local-runtime surfaces now align on account config plus optional head plus event replay; next coordination step is milestone closeout and any final polish outside W5
+
+### 2026-04-05 - Engineer1 W6 verification note
+
+Task:
+
+- `W6 - Close out M1 local-runtime loop`
+
+Status:
+
+- completed; verification run complete, milestone still open
+
+Files reviewed:
+
+- `cmd/safe/**`
+- `apps/web/**`
+- `docs/project/WORKBOARD.md`
+- `docs/project/INTERFACES.md`
+- `README.md`
+
+Verification:
+
+- `GOCACHE=/tmp/go-build go test ./...`
+- `npm test --prefix apps/web`
+- `npm run check --prefix apps/web` fails in this environment because `tsc` is not installed on `PATH`
+
+Finding:
+
+- the CLI path and web runtime helpers are real and test-backed
+- `apps/web` still contains only package code plus tests, not a navigable authenticated client surface
+
+Next action:
+
+- record M1 as still open for the missing client-surface requirement
+- close W5 cleanly and queue the missing client-surface slice as a separate task

--- a/docs/project/INTERFACES.md
+++ b/docs/project/INTERFACES.md
@@ -178,6 +178,7 @@ Current gap:
 
 - W5 moved the web runtime toward the same account-local concepts as the CLI path
 - browser-specific storage adapter details and unlock UX remain thinner than the CLI path
+- `apps/web` is still a runtime helper package rather than a navigable authenticated client surface
 
 Target:
 
@@ -188,6 +189,7 @@ Rules:
 - do not invent a separate unlock model in `apps/web`
 - persisted workspace snapshots are transitional and should not become the final runtime API
 - runtime persistence should prefer account config, collection head, replayable events, and opaque secret-material boundaries over derived UI state
+- M1 is not complete until those runtime helpers are exposed through a real client surface instead of test-only package entry points
 
 ## I5 - Handoff Protocol
 

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -42,6 +42,12 @@ Goal:
 - close or lock the client
 - reopen or unlock and read that secret back
 
+Current status:
+
+- CLI local-runtime save or read is shipped and test-backed
+- web local-runtime persistence helpers are shipped and test-backed
+- the milestone is still open because `apps/web` is currently a runtime package, not a navigable authenticated client surface
+
 Non-goals for this milestone:
 
 - sharing
@@ -298,77 +304,160 @@ GitHub issue:
 
 - `#2`
 
+### W6 - Close out M1 local-runtime loop
+
+Owner:
+
+- Engineer1
+
+Status:
+
+- completed (`refs #21`)
+
+Write scope:
+
+- `docs/project/**`
+- `README.md`
+- test-only updates in `cmd/safe/**` or `apps/web/**` if verification gaps require them
+
+Output:
+
+- verified milestone closeout notes for the shipped runtime work
+- explicit follow-up tasks for any remaining critical-path gap
+
+Dependencies:
+
+- W5
+
+GitHub issue:
+
+- `#21`
+
 ## Next Assignment
 
-M1 closeout planning is now active under milestone issue `#1`.
+No new implementation slice is assigned on this branch.
 
 Current focus:
 
-- close out `M1 - First Trustworthy Local Loop`
-- capture post-W5 polish as explicit follow-up work instead of reopening completed milestone tasks
-- split next execution into one stabilization slice and one product-surface slice so Codex and Claude can run in parallel after PM sign-off
+- keep M1 open until W10 delivers the missing real client surface
+- keep non-M1 foundational work queued, but do not let it replace the missing real-client milestone work
 
-Planned next slices (`refs #1`; create dedicated issues before coding):
+## Queued Tasks
 
-### W6 - M1 closeout audit and release checklist
+### W10 - Deliver a real M1 client surface
 
 Owner:
 
-- Engineer1 (Codex)
+- Engineer1
 
 Status:
 
-- planned
+- todo
 
 Write scope:
 
-- `docs/project/WORKBOARD.md`
-- `docs/project/HANDOFFS.md`
+- `apps/web/**`
+- `cmd/control-plane/**` if the client surface needs the existing dev identity bootstrap path
+- minimal doc updates in `docs/project/**` if the surface contract changes
+
+Output:
+
+- a navigable client surface where a user can identify, save one secret, lock or reload, and read it back
+
+Dependencies:
+
+- W5
+
+GitHub issue:
+
+- `#22`
+
+### W7 - Freeze recovery-key account contract
+
+Owner:
+
+- Engineer1
+
+Status:
+
+- todo (`refs #20`)
+
+Write scope:
+
+- `docs/project/INTERFACES.md`
 - `docs/project/DECISIONS.md`
-- release-readiness notes in `docs/architecture/IMPLEMENTATION_PLAN.md` only
+- `docs/project/HANDOFFS.md`
 
 Output:
 
-- audited mapping between docs, issue states, and project board status values
-- explicit release checklist for the first trustworthy local loop (lock or unlock, restart readback, known failure modes)
-- list of any missing follow-up issues required before milestone close
+- frozen persisted recovery-key contract for account bootstrap and account recovery
 
 Dependencies:
 
-- W1-W5 complete
+- W1
+- W3
 
 GitHub issue:
 
-- `#1` (dedicated W6 issue to be created)
+- `#20`
 
-### W7 - Post-M1 UX and reliability backlog definition
+### W8 - Implement recovery-key wrap and recovery tests
 
 Owner:
 
-- Engineer2 (Claude)
+- Engineer2
 
 Status:
 
-- planned
+- todo (`refs #19`)
 
 Write scope:
 
-- issue drafts and labels in GitHub only
-- summary sync in `docs/project/HANDOFFS.md`
+- `internal/crypto/**`
+- supporting account-domain records if required
+- test vectors or fixtures if needed
 
 Output:
 
-- prioritized backlog proposals grouped by severity (`must-fix`, `should-fix`, `nice-to-have`)
-- issue labels normalized for planning visibility (`area/*`, `type/*`, `priority/*`)
-- project-ready candidate slices with acceptance criteria and dependency notes
+- recovery-key generation plus AMK wrap and unwrap support
+- persisted-account recovery tests and wrong-key or corrupted-payload coverage
 
 Dependencies:
 
-- W6 closeout checklist draft
+- W7
 
 GitHub issue:
 
-- `#1` (dedicated W7 issue to be created)
+- `#19`
+
+### W9 - Freeze signed mutable metadata and rollback rules
+
+Owner:
+
+- Engineer1
+
+Status:
+
+- todo (`refs #18`)
+
+Write scope:
+
+- `docs/project/INTERFACES.md`
+- `docs/project/DECISIONS.md`
+- `docs/project/HANDOFFS.md`
+- architecture notes only where wording needs alignment
+
+Output:
+
+- frozen contract for signed mutable metadata, freshness checks, and rollback-sensitive objects
+
+Dependencies:
+
+- W1
+
+GitHub issue:
+
+- `#18`
 
 ## Merge Order
 


### PR DESCRIPTION
Refs #21
Refs #22
Milestone: M1 - First Trustworthy Local Loop

## Summary
- rebase the W6 closeout branch onto the latest `main` planning updates
- record that the CLI path and web runtime helpers are real and test-backed on `main`
- keep M1 open because `apps/web` is still a runtime package rather than a navigable authenticated client surface
- queue W10 explicitly as the missing client-surface slice

## Verification
- `GOCACHE=/tmp/go-build go test ./...`
- `npm test --prefix apps/web`
- `npm run check --prefix apps/web` *(fails in this environment because `tsc` is not installed on `PATH`)*