### PR TITLE
feat(web): add local M1 client surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,22 +43,21 @@ Useful progress already landed:
 - shared Go and TypeScript protocol models plus canonical fixture coverage
 - a script-friendly CLI prototype for local secret CRUD, history, import/export, and JSON output
 - durable file-backed local runtime wiring in the CLI, including password-derived unlock and encrypted secret-material storage
-- web local runtime persistence aligned around account config, optional head state, replayable events, and locked-at-rest secret handling
+- a local server-rendered web client that identifies, unlocks, saves one login secret, locks, and reopens against the same account-local runtime concepts
 - full Go test coverage for the current local-runtime path passes on `main`
 
-But the project is still behind the plan's actual critical path:
+The repository still has important v1 gaps after M1:
 
-- there is still no navigable authenticated client surface for the first trustworthy save or read loop
 - cryptographic key hierarchy and recovery flows are still missing
 - signed mutable metadata and rollback detection are still missing
 - object-store sync is still a starter model, not the intended v1 storage protocol
 
 ## Immediate Next Steps
 
-1. Deliver a real client surface for the M1 save or read loop instead of relying on runtime packages and tests alone.
-2. Close M1 only after that client can identify, save, lock or reload, and read the same secret back.
-3. Pull the next milestone boundary forward only after the remaining critical-path gaps are explicit and scoped.
-4. Continue signer, rollback, and sync-hardening work only insofar as it supports that first trustworthy save/read loop, then expand outward.
+1. Move from the closed M1 loop into recovery implementation and rollback-rule hardening.
+2. Freeze the next milestone boundary before expanding surface area beyond the current local client and CLI paths.
+3. Keep browser-native adapter decisions explicit instead of backfilling them into the finished M1 scope.
+4. Continue signer and sync-hardening work only insofar as it supports the next real user-critical loop.
 
 ## Local Development
 
@@ -74,6 +73,7 @@ Quick start:
 3. Run `make up`.
 4. Run `make logs` to follow service output.
 5. Run `make watch` if you want Compose-managed restart behavior on Go file changes.
+6. Run `npm start --prefix apps/web` to launch the local M1 web client surface.
 
 When multiple engineers or agents run the stack on the same machine, each one needs a unique Compose namespace as well as unique host ports. Set the shared identity in your local `.env`:
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "node --experimental-strip-types src/main.ts",
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json",
     "test": "node --test --experimental-strip-types test/**/*.test.mjs"

--- a/apps/web/src/local-runtime.ts
+++ b/apps/web/src/local-runtime.ts
@@ -1,0 +1,649 @@
+import {
+  argon2Sync,
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from "node:crypto";
+import {
+  access,
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+import {
+  createVaultWorkspace,
+  type VaultSecretMaterial,
+  type VaultWorkspace,
+} from "./index.ts";
+import {
+  parseAccountConfigRecord,
+  parseCollectionHeadRecord,
+  parseVaultEventRecord,
+  parseVaultItemRecord,
+  type AccountConfigRecord,
+  type CollectionHeadRecord,
+  type VaultEventRecord,
+} from "../../../packages/ts-sdk/src/index.ts";
+
+const localUnlockSchemaVersion = 1;
+const localUnlockAADPrefix = "safe.local-unlock.v1/";
+const secretEnvelopeSchemaVersion = 1;
+const secretEnvelopeAAD = "safe.secret-material.v1";
+const argonMemoryKiB = 64 * 1024;
+const argonTimeCost = 3;
+const argonParallelism = 4;
+const accountKeyBytes = 32;
+const gcmNonceBytes = 12;
+const gcmTagBytes = 16;
+const defaultCollectionId = "vault-personal";
+
+export type ClientIdentity = {
+  accountId: string;
+  deviceId: string;
+  env: string;
+};
+
+export type LocalUnlockRecord = {
+  schemaVersion: 1;
+  accountId: string;
+  kdf: {
+    name: "argon2id";
+    salt: string;
+    memoryKiB: number;
+    timeCost: number;
+    parallelism: number;
+    keyBytes: number;
+  };
+  wrappedKey: {
+    algorithm: "aes-256-gcm";
+    nonce: string;
+    ciphertext: string;
+  };
+};
+
+type SecretMaterialEnvelope = {
+  schemaVersion: 1;
+  algorithm: "aes-256-gcm";
+  nonce: string;
+  ciphertext: string;
+};
+
+export type UnlockedLocalVault = {
+  workspace: VaultWorkspace;
+  secretMaterial: VaultSecretMaterial;
+  accountKey: Buffer;
+};
+
+export type LocalRuntimeStoreOptions = {
+  baseDir: string;
+};
+
+export function createLocalRuntimeStore(options: LocalRuntimeStoreOptions) {
+  return {
+    hasUnlockRecord(accountId: string): Promise<boolean> {
+      return fileExists(unlockRecordPath(options.baseDir, accountId));
+    },
+
+    async unlock(
+      identity: ClientIdentity,
+      password: string,
+    ): Promise<{ firstUse: boolean } & UnlockedLocalVault> {
+      const firstUse = !(await fileExists(
+        unlockRecordPath(options.baseDir, identity.accountId),
+      ));
+
+      if (firstUse) {
+        const unlocked = await createFirstUseVault(options.baseDir, identity, password);
+        return {
+          firstUse: true,
+          ...unlocked,
+        };
+      }
+
+      const unlocked = await loadUnlockedVault(options.baseDir, identity, password);
+      return {
+        firstUse: false,
+        ...unlocked,
+      };
+    },
+
+    loadUnlockedWithAccountKey(
+      identity: ClientIdentity,
+      accountKey: Buffer,
+    ): Promise<UnlockedLocalVault> {
+      return loadUnlockedVaultWithAccountKey(
+        options.baseDir,
+        identity,
+        accountKey,
+      );
+    },
+
+    persistUnlockedVault(
+      identity: ClientIdentity,
+      unlocked: UnlockedLocalVault,
+    ): Promise<void> {
+      return persistUnlockedVault(options.baseDir, identity, unlocked);
+    },
+  };
+}
+
+async function createFirstUseVault(
+  baseDir: string,
+  identity: ClientIdentity,
+  password: string,
+): Promise<UnlockedLocalVault> {
+  if (password.trim() === "") {
+    throw new Error("password is required");
+  }
+
+  const { record, accountKey } = createLocalUnlockRecord(identity.accountId, password);
+  const workspace = createVaultWorkspace({
+    accountConfig: createDefaultAccountConfig(identity),
+    head: null,
+    events: [],
+  });
+  const unlocked = {
+    workspace,
+    secretMaterial: {},
+    accountKey,
+  };
+
+  await writeJSON(
+    unlockRecordPath(baseDir, identity.accountId),
+    record,
+  );
+  await persistUnlockedVault(baseDir, identity, unlocked);
+  return unlocked;
+}
+
+async function loadUnlockedVault(
+  baseDir: string,
+  identity: ClientIdentity,
+  password: string,
+): Promise<UnlockedLocalVault> {
+  const record = parseLocalUnlockRecord(
+    JSON.parse(await readFile(unlockRecordPath(baseDir, identity.accountId), "utf8")),
+  );
+  const accountKey = openLocalUnlockRecord(record, password);
+  return loadUnlockedVaultWithAccountKey(baseDir, identity, accountKey);
+}
+
+async function loadUnlockedVaultWithAccountKey(
+  baseDir: string,
+  identity: ClientIdentity,
+  accountKey: Buffer,
+): Promise<UnlockedLocalVault> {
+  const accountConfig = parseAccountConfigRecord(
+    JSON.parse(await readFile(accountConfigPath(baseDir, identity.accountId), "utf8")),
+  );
+  const head = await readOptionalJSON(
+    collectionHeadPath(
+      baseDir,
+      identity.accountId,
+      accountConfig.defaultCollectionId,
+    ),
+    parseCollectionHeadRecord,
+  );
+  const events = await readEvents(
+    baseDir,
+    identity.accountId,
+    accountConfig.defaultCollectionId,
+  );
+  const workspace = createVaultWorkspace({
+    accountConfig,
+    head,
+    events,
+  });
+
+  return {
+    workspace,
+    secretMaterial: await readSecretMaterial(
+      baseDir,
+      identity.accountId,
+      accountConfig.defaultCollectionId,
+      accountKey,
+    ),
+    accountKey,
+  };
+}
+
+async function persistUnlockedVault(
+  baseDir: string,
+  identity: ClientIdentity,
+  unlocked: UnlockedLocalVault,
+): Promise<void> {
+  const accountId = identity.accountId;
+  const collectionId =
+    unlocked.workspace.accountConfig.defaultCollectionId ?? defaultCollectionId;
+  const collectionBaseDir = collectionDir(baseDir, accountId, collectionId);
+
+  await writeJSON(accountConfigPath(baseDir, accountId), unlocked.workspace.accountConfig);
+  await mkdir(collectionBaseDir, { recursive: true });
+
+  if (unlocked.workspace.head === null) {
+    await rm(collectionHeadPath(baseDir, accountId, collectionId), {
+      force: true,
+    });
+  } else {
+    await writeJSON(
+      collectionHeadPath(baseDir, accountId, collectionId),
+      unlocked.workspace.head,
+    );
+  }
+
+  await rewriteDirectory(
+    itemDir(baseDir, accountId, collectionId),
+    unlocked.workspace.itemRecords.map((record) => ({
+      name: `${record.item.id}.json`,
+      payload: JSON.stringify(record, null, 2),
+    })),
+  );
+  await rewriteDirectory(
+    eventDir(baseDir, accountId, collectionId),
+    unlocked.workspace.events.map((event) => ({
+      name: `${event.eventId}.json`,
+      payload: JSON.stringify(event, null, 2),
+    })),
+  );
+  await rewriteDirectory(
+    secretDir(baseDir, accountId, collectionId),
+    await Promise.all(
+      Object.entries(unlocked.secretMaterial).map(async ([secretRef, secret]) => ({
+        name: `${encodeBase64Url(secretRef)}.txt`,
+        payload: JSON.stringify(
+          encryptSecretMaterial(unlocked.accountKey, Buffer.from(secret, "utf8")),
+          null,
+          2,
+        ),
+      })),
+    ),
+  );
+}
+
+function createDefaultAccountConfig(identity: ClientIdentity): AccountConfigRecord {
+  return {
+    schemaVersion: 1,
+    accountId: identity.accountId,
+    defaultCollectionId,
+    collectionIds: [defaultCollectionId],
+    deviceIds: [identity.deviceId],
+  };
+}
+
+function createLocalUnlockRecord(
+  accountId: string,
+  password: string,
+): {
+  record: LocalUnlockRecord;
+  accountKey: Buffer;
+} {
+  if (accountId.trim() === "") {
+    throw new Error("accountId is required");
+  }
+  if (password.trim() === "") {
+    throw new Error("password is required");
+  }
+
+  const salt = randomBytes(16);
+  const accountKey = randomBytes(accountKeyBytes);
+  const kdf = {
+    name: "argon2id" as const,
+    salt: encodeBase64Url(salt),
+    memoryKiB: argonMemoryKiB,
+    timeCost: argonTimeCost,
+    parallelism: argonParallelism,
+    keyBytes: accountKeyBytes,
+  };
+  const kek = deriveKey(password, kdf);
+  const wrappedKey = encryptBytes(
+    kek,
+    accountKey,
+    Buffer.from(localUnlockAAD(accountId), "utf8"),
+  );
+
+  return {
+    record: {
+      schemaVersion: localUnlockSchemaVersion,
+      accountId,
+      kdf,
+      wrappedKey: {
+        algorithm: "aes-256-gcm",
+        nonce: encodeBase64Url(wrappedKey.nonce),
+        ciphertext: encodeBase64Url(wrappedKey.ciphertext),
+      },
+    },
+    accountKey,
+  };
+}
+
+function openLocalUnlockRecord(
+  record: LocalUnlockRecord,
+  password: string,
+): Buffer {
+  if (password.trim() === "") {
+    throw new Error("password is required");
+  }
+
+  const kek = deriveKey(password, record.kdf);
+
+  try {
+    return decryptBytes(
+      kek,
+      decodeBase64Url(record.wrappedKey.nonce),
+      decodeBase64Url(record.wrappedKey.ciphertext),
+      Buffer.from(localUnlockAAD(record.accountId), "utf8"),
+    );
+  } catch {
+    throw new Error("local unlock authentication failed");
+  }
+}
+
+function encryptSecretMaterial(
+  accountKey: Buffer,
+  plaintext: Buffer,
+): SecretMaterialEnvelope {
+  const sealed = encryptBytes(
+    accountKey,
+    plaintext,
+    Buffer.from(secretEnvelopeAAD, "utf8"),
+  );
+
+  return {
+    schemaVersion: secretEnvelopeSchemaVersion,
+    algorithm: "aes-256-gcm",
+    nonce: encodeBase64Url(sealed.nonce),
+    ciphertext: encodeBase64Url(sealed.ciphertext),
+  };
+}
+
+function decryptSecretMaterial(
+  accountKey: Buffer,
+  envelope: SecretMaterialEnvelope,
+): Buffer {
+  try {
+    return decryptBytes(
+      accountKey,
+      decodeBase64Url(envelope.nonce),
+      decodeBase64Url(envelope.ciphertext),
+      Buffer.from(secretEnvelopeAAD, "utf8"),
+    );
+  } catch {
+    throw new Error("secret material authentication failed");
+  }
+}
+
+function deriveKey(
+  password: string,
+  kdf: LocalUnlockRecord["kdf"],
+): Buffer {
+  return argon2Sync("argon2id", {
+    message: Buffer.from(password, "utf8"),
+    nonce: decodeBase64Url(kdf.salt),
+    parallelism: kdf.parallelism,
+    tagLength: kdf.keyBytes,
+    memory: kdf.memoryKiB,
+    passes: kdf.timeCost,
+  });
+}
+
+function encryptBytes(
+  key: Buffer,
+  plaintext: Buffer,
+  aad: Buffer,
+): {
+  nonce: Buffer;
+  ciphertext: Buffer;
+} {
+  const nonce = randomBytes(gcmNonceBytes);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  cipher.setAAD(aad);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext),
+    cipher.final(),
+    cipher.getAuthTag(),
+  ]);
+
+  return {
+    nonce,
+    ciphertext,
+  };
+}
+
+function decryptBytes(
+  key: Buffer,
+  nonce: Buffer,
+  ciphertext: Buffer,
+  aad: Buffer,
+): Buffer {
+  if (ciphertext.length <= gcmTagBytes) {
+    throw new Error("ciphertext is truncated");
+  }
+
+  const tag = ciphertext.subarray(ciphertext.length - gcmTagBytes);
+  const sealed = ciphertext.subarray(0, ciphertext.length - gcmTagBytes);
+  const decipher = createDecipheriv("aes-256-gcm", key, nonce);
+  decipher.setAAD(aad);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(sealed), decipher.final()]);
+}
+
+function parseLocalUnlockRecord(value: unknown): LocalUnlockRecord {
+  if (!isRecord(value)) {
+    throw new Error("invalid local unlock record");
+  }
+  if (value.schemaVersion !== 1) {
+    throw new Error("invalid local unlock record field: schemaVersion");
+  }
+  if (typeof value.accountId !== "string" || value.accountId === "") {
+    throw new Error("invalid local unlock record field: accountId");
+  }
+  if (!isRecord(value.kdf)) {
+    throw new Error("invalid local unlock record field: kdf");
+  }
+  if (
+    value.kdf.name !== "argon2id" ||
+    typeof value.kdf.salt !== "string" ||
+    typeof value.kdf.memoryKiB !== "number" ||
+    typeof value.kdf.timeCost !== "number" ||
+    typeof value.kdf.parallelism !== "number" ||
+    typeof value.kdf.keyBytes !== "number"
+  ) {
+    throw new Error("invalid local unlock record field: kdf");
+  }
+  if (!isRecord(value.wrappedKey)) {
+    throw new Error("invalid local unlock record field: wrappedKey");
+  }
+  if (
+    value.wrappedKey.algorithm !== "aes-256-gcm" ||
+    typeof value.wrappedKey.nonce !== "string" ||
+    typeof value.wrappedKey.ciphertext !== "string"
+  ) {
+    throw new Error("invalid local unlock record field: wrappedKey");
+  }
+
+  return {
+    schemaVersion: 1,
+    accountId: value.accountId,
+    kdf: {
+      name: "argon2id",
+      salt: value.kdf.salt,
+      memoryKiB: value.kdf.memoryKiB,
+      timeCost: value.kdf.timeCost,
+      parallelism: value.kdf.parallelism,
+      keyBytes: value.kdf.keyBytes,
+    },
+    wrappedKey: {
+      algorithm: "aes-256-gcm",
+      nonce: value.wrappedKey.nonce,
+      ciphertext: value.wrappedKey.ciphertext,
+    },
+  };
+}
+
+async function readEvents(
+  baseDir: string,
+  accountId: string,
+  collectionId: string,
+): Promise<VaultEventRecord[]> {
+  const dir = eventDir(baseDir, accountId, collectionId);
+  if (!(await fileExists(dir))) {
+    return [];
+  }
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  const events = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map(async (entry) =>
+        parseVaultEventRecord(
+          JSON.parse(await readFile(path.join(dir, entry.name), "utf8")),
+        ),
+      ),
+  );
+
+  return events.sort(
+    (left, right) =>
+      left.sequence - right.sequence ||
+      left.eventId.localeCompare(right.eventId),
+  );
+}
+
+async function readSecretMaterial(
+  baseDir: string,
+  accountId: string,
+  collectionId: string,
+  accountKey: Buffer,
+): Promise<VaultSecretMaterial> {
+  const dir = secretDir(baseDir, accountId, collectionId);
+  if (!(await fileExists(dir))) {
+    return {};
+  }
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  const secretPairs = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".txt"))
+      .map(async (entry) => {
+        const secretRef = decodeBase64Url(entry.name.slice(0, -4)).toString("utf8");
+        const envelope = JSON.parse(await readFile(path.join(dir, entry.name), "utf8"));
+        const plaintext = decryptSecretMaterial(accountKey, envelope);
+        return [secretRef, plaintext.toString("utf8")] as const;
+      }),
+  );
+
+  return Object.fromEntries(secretPairs);
+}
+
+async function rewriteDirectory(
+  dir: string,
+  files: Array<{
+    name: string;
+    payload: string;
+  }>,
+): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+  await mkdir(dir, { recursive: true });
+
+  await Promise.all(
+    files.map((file) =>
+      writeFile(path.join(dir, file.name), file.payload, "utf8"),
+    ),
+  );
+}
+
+async function writeJSON(filePath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(value, null, 2), "utf8");
+}
+
+async function readOptionalJSON<T>(
+  filePath: string,
+  parse: (value: unknown) => T,
+): Promise<T | null> {
+  if (!(await fileExists(filePath))) {
+    return null;
+  }
+
+  return parse(JSON.parse(await readFile(filePath, "utf8")));
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function encodeBase64Url(value: Buffer | string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function decodeBase64Url(value: string): Buffer {
+  return Buffer.from(value, "base64url");
+}
+
+function localUnlockAAD(accountId: string): string {
+  return `${localUnlockAADPrefix}${accountId}`;
+}
+
+function accountBaseDir(baseDir: string, accountId: string): string {
+  return path.join(baseDir, "accounts", accountId);
+}
+
+function collectionDir(
+  baseDir: string,
+  accountId: string,
+  collectionId: string,
+): string {
+  return path.join(accountBaseDir(baseDir, accountId), "collections", collectionId);
+}
+
+function accountConfigPath(baseDir: string, accountId: string): string {
+  return path.join(accountBaseDir(baseDir, accountId), "account.json");
+}
+
+function unlockRecordPath(baseDir: string, accountId: string): string {
+  return path.join(accountBaseDir(baseDir, accountId), "unlock.json");
+}
+
+function collectionHeadPath(
+  baseDir: string,
+  accountId: string,
+  collectionId: string,
+): string {
+  return path.join(collectionDir(baseDir, accountId, collectionId), "head.json");
+}
+
+function itemDir(
+  baseDir: string,
+  accountId: string,
+  collectionId: string,
+): string {
+  return path.join(collectionDir(baseDir, accountId, collectionId), "items");
+}
+
+function eventDir(
+  baseDir: string,
+  accountId: string,
+  collectionId: string,
+): string {
+  return path.join(collectionDir(baseDir, accountId, collectionId), "events");
+}
+
+function secretDir(
+  baseDir: string,
+  accountId: string,
+  collectionId: string,
+): string {
+  return path.join(collectionDir(baseDir, accountId, collectionId), "secrets");
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,0 +1,8 @@
+import { createServer } from "./server.ts";
+
+const port = Number(process.env.SAFE_WEB_PORT ?? process.env.PORT ?? "3000");
+const server = createServer();
+
+server.listen(port, () => {
+  process.stdout.write(`safe web client listening on http://127.0.0.1:${port}\n`);
+});

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,0 +1,756 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import http from "node:http";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import {
+  addLoginToVaultWorkspace,
+  getVaultItemDetail,
+  getVaultLoginCredentialDetail,
+} from "./index.ts";
+import {
+  createLocalRuntimeStore,
+  type ClientIdentity,
+} from "./local-runtime.ts";
+
+type SessionState = {
+  identity: ClientIdentity | null;
+  accountKey: Buffer | null;
+};
+
+export type WebClientServerOptions = {
+  dataDir?: string;
+  now?: () => Date;
+  resolveIdentity?: () => Promise<ClientIdentity>;
+};
+
+export function createWebClientServer(
+  options: WebClientServerOptions = {},
+): http.RequestListener {
+  const dataDir =
+    options.dataDir ??
+    process.env.SAFE_WEB_DATA_DIR ??
+    path.join(process.cwd(), "apps/web/.safe-client-data");
+  const store = createLocalRuntimeStore({ baseDir: dataDir });
+  const now = options.now ?? (() => new Date());
+  const resolveIdentity = options.resolveIdentity ?? defaultResolveIdentity;
+  const sessions = new Map<string, SessionState>();
+
+  return (request, response) => {
+    void handleRequest(request, response).catch((error: unknown) => {
+      const message =
+        error instanceof Error ? error.message : "unexpected server error";
+      writeHTML(
+        response,
+        500,
+        renderPage({
+          title: "Safe",
+          body: `
+            <section class="panel stack">
+              <p class="eyebrow">Server Error</p>
+              <h1>Request failed</h1>
+              <p>${escapeHTML(message)}</p>
+              <p><a class="link" href="/">Return home</a></p>
+            </section>
+          `,
+        }),
+      );
+    });
+  };
+
+  async function handleRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    const url = new URL(request.url ?? "/", "http://safe.local");
+    const session = getOrCreateSession(request, response);
+
+    if (request.method === "GET" && url.pathname === "/") {
+      if (session.identity) {
+        redirect(response, session.accountKey ? "/vault" : "/unlock");
+        return;
+      }
+
+      writeHTML(response, 200, renderHomePage());
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/identify") {
+      session.identity = await resolveIdentity();
+      session.accountKey = null;
+      redirect(response, "/unlock");
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/unlock") {
+      if (!session.identity) {
+        redirect(response, "/");
+        return;
+      }
+
+      const firstUse = !(await store.hasUnlockRecord(session.identity.accountId));
+      writeHTML(
+        response,
+        200,
+        renderUnlockPage({
+          identity: session.identity,
+          firstUse,
+        }),
+      );
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/unlock") {
+      if (!session.identity) {
+        redirect(response, "/");
+        return;
+      }
+
+      const form = await readForm(request);
+      const password = form.get("password")?.trim() ?? "";
+      const firstUse = !(await store.hasUnlockRecord(session.identity.accountId));
+
+      try {
+        const unlocked = await store.unlock(session.identity, password);
+        session.accountKey = unlocked.accountKey;
+        redirect(response, "/vault");
+        return;
+      } catch {
+        writeHTML(
+          response,
+          200,
+          renderUnlockPage({
+            identity: session.identity,
+            firstUse,
+            error:
+              firstUse
+                ? "Safe could not create local unlock state with that password."
+                : "Unlock failed. Check the password and try again.",
+          }),
+        );
+        return;
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/lock") {
+      session.accountKey = null;
+      redirect(response, "/unlock");
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/logout") {
+      session.identity = null;
+      session.accountKey = null;
+      redirect(response, "/");
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/vault") {
+      if (!session.identity || !session.accountKey) {
+        redirect(response, "/unlock");
+        return;
+      }
+
+      const unlocked = await store.loadUnlockedWithAccountKey(
+        session.identity,
+        session.accountKey,
+      );
+      writeHTML(
+        response,
+        200,
+        renderVaultPage({
+          identity: session.identity,
+          itemId: url.searchParams.get("item"),
+          unlocked,
+        }),
+      );
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/vault/login") {
+      if (!session.identity || !session.accountKey) {
+        redirect(response, "/unlock");
+        return;
+      }
+
+      const form = await readForm(request);
+      const unlocked = await store.loadUnlockedWithAccountKey(
+        session.identity,
+        session.accountKey,
+      );
+
+      try {
+        const result = await addLoginToVaultWorkspace({
+          workspace: unlocked.workspace,
+          secretMaterial: unlocked.secretMaterial,
+          deviceId: session.identity.deviceId,
+          title: form.get("title") ?? "",
+          username: form.get("username") ?? "",
+          url: form.get("url") ?? "",
+          password: form.get("password") ?? "",
+          tags: ["manual", "m1"],
+          at: now(),
+        });
+
+        await store.persistUnlockedVault(session.identity, {
+          workspace: result.workspace,
+          secretMaterial: result.secretMaterial,
+          accountKey: session.accountKey,
+        });
+        redirect(response, `/vault?item=${encodeURIComponent(result.itemId)}`);
+        return;
+      } catch (error) {
+        writeHTML(
+          response,
+          200,
+          renderVaultPage({
+            identity: session.identity,
+            unlocked,
+            itemId: null,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Safe could not save that secret.",
+          }),
+        );
+        return;
+      }
+    }
+
+    writeHTML(
+      response,
+      404,
+      renderPage({
+        title: "Safe",
+        body: `
+          <section class="panel stack">
+            <p class="eyebrow">Missing</p>
+            <h1>Nothing here</h1>
+            <p>The route <code>${escapeHTML(url.pathname)}</code> does not exist.</p>
+            <p><a class="link" href="/">Return home</a></p>
+          </section>
+        `,
+      }),
+    );
+  }
+
+  function getOrCreateSession(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): SessionState {
+    const existing = parseCookies(request.headers.cookie ?? "").safe_web_session;
+    if (existing && sessions.has(existing)) {
+      return sessions.get(existing)!;
+    }
+
+    const sessionId = randomUUID();
+    const session = {
+      identity: null,
+      accountKey: null,
+    };
+    sessions.set(sessionId, session);
+    response.setHeader("Set-Cookie", serializeCookie("safe_web_session", sessionId));
+    return session;
+  }
+}
+
+export function createServer(options: WebClientServerOptions = {}): http.Server {
+  return http.createServer(createWebClientServer(options));
+}
+
+function renderHomePage(): string {
+  return renderPage({
+    title: "Safe",
+    body: `
+      <section class="hero">
+        <div class="hero-copy stack">
+          <p class="eyebrow">M1 Client Surface</p>
+          <h1>Identify, unlock, save one secret, and read it back.</h1>
+          <p class="lede">
+            This local web client runs the real runtime helpers instead of test-only package code.
+            It keeps account config, head state, replayable events, and encrypted secret material on disk.
+          </p>
+          <form method="post" action="/identify">
+            <button class="button button-primary" type="submit">Start dev session</button>
+          </form>
+        </div>
+        <aside class="hero-panel stack">
+          <p class="eyebrow">Flow</p>
+          <ol class="steps">
+            <li>Identify into the local client.</li>
+            <li>Create or reuse the account password unlock path.</li>
+            <li>Save one login secret into the durable local runtime.</li>
+            <li>Lock or restart, unlock again, and read the same secret back.</li>
+          </ol>
+        </aside>
+      </section>
+    `,
+  });
+}
+
+function renderUnlockPage(input: {
+  identity: ClientIdentity;
+  firstUse: boolean;
+  error?: string;
+}): string {
+  const title = input.firstUse ? "Create local vault password" : "Unlock local vault";
+  const detail = input.firstUse
+    ? "First use creates the account-local unlock record and an empty durable runtime."
+    : "Unlock uses the persisted account-scoped Argon2id record and reopens the durable runtime.";
+
+  return renderPage({
+    title: "Safe Unlock",
+    body: `
+      <section class="panel stack">
+        <p class="eyebrow">${input.firstUse ? "First Use" : "Unlock"}</p>
+        <h1>${title}</h1>
+        <p>${detail}</p>
+        ${input.error ? `<p class="error">${escapeHTML(input.error)}</p>` : ""}
+        <dl class="meta-grid">
+          <div><dt>Account</dt><dd>${escapeHTML(input.identity.accountId)}</dd></div>
+          <div><dt>Device</dt><dd>${escapeHTML(input.identity.deviceId)}</dd></div>
+          <div><dt>Env</dt><dd>${escapeHTML(input.identity.env)}</dd></div>
+        </dl>
+        <form class="stack" method="post" action="/unlock">
+          <label class="field">
+            <span>Password</span>
+            <input name="password" type="password" autocomplete="current-password" required />
+          </label>
+          <div class="actions">
+            <button class="button button-primary" type="submit">
+              ${input.firstUse ? "Create vault" : "Unlock vault"}
+            </button>
+            <a class="button button-secondary" href="/">Start over</a>
+          </div>
+        </form>
+      </section>
+    `,
+  });
+}
+
+function renderVaultPage(input: {
+  identity: ClientIdentity;
+  unlocked: Awaited<ReturnType<ReturnType<typeof createLocalRuntimeStore>["unlock"]>>;
+  itemId: string | null;
+  error?: string;
+}): string {
+  const selectedItemId =
+    input.itemId ??
+    input.unlocked.workspace.itemRecords.find((record) => record.item.kind === "login")?.item.id ??
+    null;
+  const selectedLogin =
+    selectedItemId === null
+      ? null
+      : getSafeLoginDetail(
+          input.unlocked.workspace,
+          input.unlocked.secretMaterial,
+          selectedItemId,
+        );
+  const itemsMarkup =
+    input.unlocked.workspace.itemRecords.length === 0
+      ? `<p class="empty">No secrets yet. Save one login below to complete the M1 loop.</p>`
+      : `
+        <ul class="item-list">
+          ${input.unlocked.workspace.itemRecords
+            .map((record) => {
+              const detail = getVaultItemDetail(input.unlocked.workspace, record.item.id);
+              return `
+                <li>
+                  <a class="item-link" href="/vault?item=${encodeURIComponent(record.item.id)}">
+                    <span class="item-title">${escapeHTML(detail.title)}</span>
+                    <span class="item-summary">${escapeHTML(detail.summary)}</span>
+                  </a>
+                </li>
+              `;
+            })
+            .join("")}
+        </ul>
+      `;
+  const detailMarkup =
+    selectedLogin === null
+      ? `
+        <div class="detail-empty">
+          <p class="eyebrow">Read Path</p>
+          <h2>No login selected</h2>
+          <p>Save a login, then lock or restart and unlock again to confirm the durable read path.</p>
+        </div>
+      `
+      : `
+        <div class="detail-card stack">
+          <p class="eyebrow">Selected Secret</p>
+          <h2>${escapeHTML(selectedLogin.title)}</h2>
+          <dl class="detail-grid">
+            <div><dt>Username</dt><dd>${escapeHTML(selectedLogin.username)}</dd></div>
+            <div><dt>URL</dt><dd>${escapeHTML(selectedLogin.primaryURL ?? "n/a")}</dd></div>
+            <div><dt>Password</dt><dd><code>${escapeHTML(selectedLogin.password ?? "locked")}</code></dd></div>
+            <div><dt>Status</dt><dd>${escapeHTML(selectedLogin.passwordStatus)}</dd></div>
+          </dl>
+        </div>
+      `;
+
+  return renderPage({
+    title: "Safe Vault",
+    body: `
+      <header class="vault-header">
+        <div>
+          <p class="eyebrow">Unlocked Vault</p>
+          <h1>${escapeHTML(input.identity.accountId)}</h1>
+        </div>
+        <div class="actions">
+          <form method="post" action="/lock"><button class="button button-secondary" type="submit">Lock</button></form>
+          <form method="post" action="/logout"><button class="button button-secondary" type="submit">Sign out</button></form>
+        </div>
+      </header>
+
+      <section class="stats-grid">
+        <article class="stat-card">
+          <span class="stat-label">Items</span>
+          <strong>${input.unlocked.workspace.overview.itemCount}</strong>
+        </article>
+        <article class="stat-card">
+          <span class="stat-label">Latest seq</span>
+          <strong>${input.unlocked.workspace.overview.latestSeq}</strong>
+        </article>
+        <article class="stat-card">
+          <span class="stat-label">Events</span>
+          <strong>${input.unlocked.workspace.events.length}</strong>
+        </article>
+      </section>
+
+      ${input.error ? `<p class="error">${escapeHTML(input.error)}</p>` : ""}
+
+      <section class="vault-grid">
+        <section class="panel stack">
+          <p class="eyebrow">Save Secret</p>
+          <h2>Add one login</h2>
+          <form class="stack" method="post" action="/vault/login">
+            <label class="field"><span>Title</span><input name="title" type="text" value="GitHub" required /></label>
+            <label class="field"><span>Username</span><input name="username" type="text" value="alice" required /></label>
+            <label class="field"><span>URL</span><input name="url" type="url" value="https://github.com/login" required /></label>
+            <label class="field"><span>Password</span><input name="password" type="text" value="ghp-secret-123" required /></label>
+            <button class="button button-primary" type="submit">Save secret</button>
+          </form>
+        </section>
+
+        <section class="panel stack">
+          <p class="eyebrow">Vault Items</p>
+          <h2>Replay-backed records</h2>
+          ${itemsMarkup}
+        </section>
+      </section>
+
+      <section class="panel">
+        ${detailMarkup}
+      </section>
+    `,
+  });
+}
+
+async function defaultResolveIdentity(): Promise<ClientIdentity> {
+  const controlPlaneURL =
+    process.env.SAFE_WEB_CONTROL_PLANE_URL ??
+    process.env.SAFE_CONTROL_PLANE_URL;
+
+  if (controlPlaneURL) {
+    try {
+      const response = await fetch(new URL("/v1/dev/session", controlPlaneURL), {
+        method: "POST",
+      });
+      if (response.ok) {
+        const payload = (await response.json()) as {
+          accountId: string;
+          deviceId: string;
+          env: string;
+        };
+        if (payload.accountId && payload.deviceId && payload.env) {
+          return payload;
+        }
+      }
+    } catch {
+      // Fall back to local defaults when the control plane is not running.
+    }
+  }
+
+  return {
+    accountId: process.env.SAFE_DEV_ACCOUNT_ID ?? "acct-dev-001",
+    deviceId: process.env.SAFE_DEV_DEVICE_ID ?? "dev-web-001",
+    env: process.env.SAFE_ENV ?? "development",
+  };
+}
+
+async function readForm(request: IncomingMessage): Promise<URLSearchParams> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return new URLSearchParams(Buffer.concat(chunks).toString("utf8"));
+}
+
+function writeHTML(
+  response: ServerResponse,
+  statusCode: number,
+  body: string,
+): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "text/html; charset=utf-8");
+  response.end(body);
+}
+
+function redirect(response: ServerResponse, location: string): void {
+  response.statusCode = 303;
+  response.setHeader("Location", location);
+  response.end();
+}
+
+function parseCookies(cookieHeader: string): Record<string, string> {
+  return Object.fromEntries(
+    cookieHeader
+      .split(";")
+      .map((part) => part.trim())
+      .filter((part) => part.includes("="))
+      .map((part) => {
+        const separator = part.indexOf("=");
+        return [part.slice(0, separator), decodeURIComponent(part.slice(separator + 1))];
+      }),
+  );
+}
+
+function serializeCookie(name: string, value: string): string {
+  return `${name}=${encodeURIComponent(value)}; Path=/; HttpOnly; SameSite=Lax`;
+}
+
+function getSafeLoginDetail(
+  workspace: Parameters<typeof getVaultLoginCredentialDetail>[0]["workspace"],
+  secretMaterial: Parameters<typeof getVaultLoginCredentialDetail>[0]["secretMaterial"],
+  itemId: string,
+) {
+  try {
+    return getVaultLoginCredentialDetail({
+      workspace,
+      itemId,
+      secretMaterial,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function renderPage(input: {
+  title: string;
+  body: string;
+}): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHTML(input.title)}</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f4efe5;
+        --bg-strong: #ece2d3;
+        --panel: rgba(255, 252, 246, 0.88);
+        --border: rgba(93, 70, 44, 0.16);
+        --text: #1f1a14;
+        --muted: #6c5a48;
+        --accent: #a04d1f;
+        --accent-strong: #7f3814;
+        --shadow: 0 24px 60px rgba(77, 55, 36, 0.12);
+      }
+
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background:
+          radial-gradient(circle at top left, rgba(209, 151, 83, 0.22), transparent 35%),
+          radial-gradient(circle at top right, rgba(92, 128, 109, 0.15), transparent 32%),
+          linear-gradient(180deg, var(--bg), #f8f4ee);
+        color: var(--text);
+        font-family: "Avenir Next", "Segoe UI", sans-serif;
+      }
+
+      h1, h2 {
+        margin: 0;
+        font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+        font-weight: 700;
+        line-height: 1.05;
+      }
+
+      p, li, dd, dt, span, a, button, input, code { font-size: 1rem; }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 48px 20px 72px;
+      }
+
+      .stack > * + * { margin-top: 1rem; }
+      .hero, .vault-grid, .stats-grid, .meta-grid, .detail-grid {
+        display: grid;
+        gap: 18px;
+      }
+
+      .hero { grid-template-columns: 1.25fr 0.95fr; align-items: stretch; }
+      .hero-copy, .hero-panel, .panel, .stat-card, .detail-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+      }
+
+      .hero-copy, .hero-panel, .panel, .detail-card { padding: 28px; }
+      .hero-copy h1 { font-size: clamp(2.8rem, 6vw, 4.7rem); max-width: 12ch; }
+      .hero-panel h2, .panel h2 { font-size: 1.8rem; }
+      .lede { color: var(--muted); max-width: 58ch; line-height: 1.6; }
+      .eyebrow {
+        margin: 0;
+        color: var(--accent);
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+      }
+
+      .steps {
+        margin: 0;
+        padding-left: 1.25rem;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      .button, .link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        text-decoration: none;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        min-height: 44px;
+        padding: 0 18px;
+        font-weight: 700;
+      }
+
+      .button-primary {
+        background: var(--accent);
+        color: white;
+      }
+
+      .button-primary:hover { background: var(--accent-strong); }
+
+      .button-secondary {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+
+      .vault-header, .actions {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+      }
+
+      .stats-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 22px 0; }
+      .stat-card { padding: 20px; }
+      .stat-label {
+        display: block;
+        color: var(--muted);
+        margin-bottom: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 0.72rem;
+      }
+      .stat-card strong { font-size: 2rem; }
+
+      .vault-grid { grid-template-columns: 1fr 1fr; }
+      .field { display: block; }
+      .field span {
+        display: block;
+        margin-bottom: 8px;
+        color: var(--muted);
+        font-weight: 700;
+      }
+
+      input {
+        width: 100%;
+        border-radius: 16px;
+        border: 1px solid rgba(93, 70, 44, 0.22);
+        padding: 14px 16px;
+        background: rgba(255, 255, 255, 0.9);
+      }
+
+      .item-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 10px;
+      }
+
+      .item-link {
+        display: block;
+        padding: 14px 16px;
+        border-radius: 18px;
+        color: inherit;
+        text-decoration: none;
+        background: rgba(247, 239, 228, 0.76);
+        border: 1px solid rgba(93, 70, 44, 0.1);
+      }
+
+      .item-title { display: block; font-weight: 700; }
+      .item-summary, .empty, .error, dt { color: var(--muted); }
+      .meta-grid, .detail-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      dt {
+        font-size: 0.76rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-bottom: 6px;
+      }
+
+      dd { margin: 0; font-weight: 700; }
+      code {
+        display: inline-block;
+        padding: 4px 8px;
+        border-radius: 10px;
+        background: rgba(93, 70, 44, 0.08);
+      }
+
+      .error {
+        margin: 0;
+        padding: 12px 14px;
+        border-radius: 16px;
+        background: rgba(194, 73, 31, 0.08);
+        border: 1px solid rgba(194, 73, 31, 0.16);
+      }
+
+      @media (max-width: 820px) {
+        .hero, .vault-grid, .stats-grid, .meta-grid, .detail-grid {
+          grid-template-columns: 1fr;
+        }
+
+        main { padding: 28px 16px 48px; }
+        .hero-copy h1 { font-size: clamp(2.4rem, 11vw, 3.3rem); }
+      }
+    </style>
+  </head>
+  <body>
+    <main>${input.body}</main>
+  </body>
+</html>`;
+}
+
+function escapeHTML(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/apps/web/test/client-surface.test.mjs
+++ b/apps/web/test/client-surface.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { createWebClientServer } from "../src/server.ts";
+
+function getSetCookie(response) {
+  const raw = response.headers["set-cookie"];
+  if (Array.isArray(raw)) {
+    return raw[0]?.split(";")[0] ?? null;
+  }
+  return raw ? raw.split(";")[0] : null;
+}
+
+function createMockResponse() {
+  const headers = {};
+  const chunks = [];
+  let finished;
+  const done = new Promise((resolve) => {
+    finished = resolve;
+  });
+
+  return {
+    statusCode: 200,
+    headers,
+    setHeader(name, value) {
+      headers[name.toLowerCase()] = value;
+    },
+    getHeader(name) {
+      return headers[name.toLowerCase()];
+    },
+    end(chunk = "") {
+      if (chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      finished();
+    },
+    async asResult() {
+      await done;
+      return {
+        status: this.statusCode,
+        headers,
+        text: Buffer.concat(chunks).toString("utf8"),
+      };
+    },
+  };
+}
+
+async function invoke(app, input) {
+  const request = new PassThrough();
+  request.method = input.method ?? "GET";
+  request.url = input.url;
+  request.headers = input.headers ?? {};
+
+  const response = createMockResponse();
+  app(request, response);
+  if (input.body) {
+    request.end(input.body.toString());
+  } else {
+    request.end();
+  }
+
+  return response.asResult();
+}
+
+test("web client can identify, save, lock, restart, unlock, and read a secret", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "safe-web-"));
+  const identity = {
+    accountId: "acct-dev-001",
+    deviceId: "dev-web-001",
+    env: "test",
+  };
+
+  try {
+    let app = createWebClientServer({
+      dataDir,
+      resolveIdentity: async () => identity,
+      now: () => new Date("2026-04-05T09:30:00Z"),
+    });
+
+    let response = await invoke(app, { url: "/" });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Start dev session/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/identify",
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/unlock");
+    let cookie = getSetCookie(response);
+    assert.ok(cookie);
+
+    response = await invoke(app, {
+      url: "/unlock",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Create local vault password/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/unlock",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        password: "correct horse battery staple",
+      }),
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/vault");
+
+    response = await invoke(app, {
+      url: "/vault",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /No secrets yet/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/vault/login",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        title: "GitHub",
+        username: "alice",
+        url: "https://github.com/login",
+        password: "ghp-secret-123",
+      }),
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/vault?item=login-github-primary");
+
+    response = await invoke(app, {
+      url: "/vault?item=login-github-primary",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /ghp-secret-123/);
+    assert.match(response.text, /login-github-primary/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/lock",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/unlock");
+
+    app = createWebClientServer({
+      dataDir,
+      resolveIdentity: async () => identity,
+      now: () => new Date("2026-04-05T09:35:00Z"),
+    });
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/identify",
+    });
+    assert.equal(response.status, 303);
+    cookie = getSetCookie(response);
+    assert.ok(cookie);
+
+    response = await invoke(app, {
+      url: "/unlock",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Unlock local vault/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/unlock",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        password: "wrong password",
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Unlock failed/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/unlock",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        password: "correct horse battery staple",
+      }),
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/vault");
+
+    response = await invoke(app, {
+      url: "/vault?item=login-github-primary",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /ghp-secret-123/);
+    assert.match(response.text, /GitHub/);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});

--- a/docs/project/DECISIONS.md
+++ b/docs/project/DECISIONS.md
@@ -302,6 +302,42 @@ Refs:
 
 - `#20`
 
+### D10 - W10 closes M1 with a local web client, not a browser-only crypto rewrite
+
+Status:
+
+- accepted
+
+Date:
+
+- 2026-04-05
+
+Owner:
+
+- Engineer1
+
+Decision:
+
+- W10 closes M1 by shipping a local server-rendered client surface under `apps/web`
+- that surface uses the accepted account-scoped unlock record and encrypted secret-material envelope instead of inventing a second web-only unlock format
+- a fully browser-native storage adapter remains a follow-up decision, not a prerequisite for closing the first trustworthy local loop
+
+Rationale:
+
+- the missing milestone gap was a navigable client surface, not another rewrite of the frozen local unlock contract
+- Node can execute the accepted Argon2id plus AES-256-GCM path today, which lets the web client complete the real save or read loop without hiding new crypto divergence in `apps/web`
+- closing M1 cleanly is better than letting browser-adapter ambiguity silently keep the milestone open
+
+Downstream impact:
+
+- `docs/project/WORKBOARD.md` and `README.md` should treat M1 as complete once W10 lands
+- post-M1 planning should keep browser-native adapter work explicit instead of backfilling it into W10
+- the web client surface should continue consuming the shared runtime model from `apps/web/src/index.ts` rather than bypassing it
+
+Refs:
+
+- `#22`
+
 ## Open Questions
 
 ### P3 - Web local runtime storage boundary
@@ -322,4 +358,4 @@ Decision driver:
 
 - avoid inventing a second runtime model
 - W5 aligned the web runtime around account config, optional head state, replayable events, and locked secret-material boundaries
-- remaining decisions should focus on browser-specific adapter details and post-M1 polish, not on inventing a second runtime model
+- W10 closed M1 with a local web client; remaining decisions should focus on browser-specific adapter details and post-M1 polish, not on inventing a second runtime model

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -340,3 +340,42 @@ Next action:
 
 - record M1 as still open for the missing client-surface requirement
 - close W5 cleanly and queue the missing client-surface slice as a separate task
+
+### 2026-04-05 - Engineer1 completion note (W10)
+
+Task:
+
+- `W10 - Deliver a real M1 client surface`
+
+Status:
+
+- completed; refs #22
+
+Files touched:
+
+- `apps/web/src/local-runtime.ts`
+- `apps/web/src/server.ts`
+- `apps/web/src/main.ts`
+- `apps/web/test/client-surface.test.mjs`
+- `apps/web/package.json`
+- `docs/project/WORKBOARD.md`
+- `docs/project/INTERFACES.md`
+- `docs/project/DECISIONS.md`
+- `docs/project/HANDOFFS.md`
+- `README.md`
+
+Verification:
+
+- `npm test --prefix apps/web`
+- `GOCACHE=/tmp/go-build go test ./...`
+
+Outcome:
+
+- `apps/web` now ships a real local client surface with routes for identify, unlock, save, lock, and reopen
+- the web client persists account config, collection head, item records, replayable events, and encrypted secret material under the accepted account-local unlock contract
+- M1 is complete; remaining browser-native adapter questions stay queued as explicit post-M1 work
+
+Next action:
+
+- close issue `#22` and milestone issue `#1`
+- keep W8 and W9 explicit as post-M1 follow-up work

--- a/docs/project/INTERFACES.md
+++ b/docs/project/INTERFACES.md
@@ -179,20 +179,21 @@ Owner:
 
 Current gap:
 
-- W5 moved the web runtime toward the same account-local concepts as the CLI path
-- browser-specific storage adapter details and unlock UX remain thinner than the CLI path
-- `apps/web` is still a runtime helper package rather than a navigable authenticated client surface
+- W10 exposed the web runtime through a local server-rendered client surface in `apps/web`
+- browser-native storage adapter details still remain thinner than the CLI path
+- future browser-native work should refine that adapter without reopening the M1 surface decision
 
 Target:
 
-- web surface consumes the same local-runtime concepts as the CLI, with a browser-specific storage adapter if needed
+- web surface consumes the same local-runtime concepts as the CLI
+- M1 is satisfied by the shipped local web client surface; a browser-specific adapter remains follow-up work if the web target moves fully in-browser
 
 Rules:
 
 - do not invent a separate unlock model in `apps/web`
 - persisted workspace snapshots are transitional and should not become the final runtime API
 - runtime persistence should prefer account config, collection head, replayable events, and opaque secret-material boundaries over derived UI state
-- M1 is not complete until those runtime helpers are exposed through a real client surface instead of test-only package entry points
+- do not treat browser-native adapter polish as grounds to reopen M1 once the real client surface is shipped
 
 ## I6 - Recovery Key Contract
 

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -45,8 +45,8 @@ Goal:
 Current status:
 
 - CLI local-runtime save or read is shipped and test-backed
-- web local-runtime persistence helpers are shipped and test-backed
-- the milestone is still open because `apps/web` is currently a runtime package, not a navigable authenticated client surface
+- a local server-rendered web client now ships in `apps/web` and completes the same identify, unlock, save, lock, and reopen loop
+- M1 is complete on `main`; remaining work is post-M1 hardening and expansion, not a hidden milestone gap
 
 Non-goals for this milestone:
 
@@ -58,8 +58,9 @@ Non-goals for this milestone:
 
 Milestone closeout status:
 
-- technical implementation slices W1-W5 are complete (`refs #2`, `#3`, `#4`, `#5`, `#6`)
-- remaining PM work is planning hygiene: verify issue states, project statuses, and define the first post-M1 queue (`refs #1`)
+- implementation slices W1-W7 and W10 are complete (`refs #2`, `#3`, `#4`, `#5`, `#6`, `#20`, `#22`)
+- the first trustworthy local loop is now closed for both the CLI and the local web client (`refs #1`)
+- remaining queued work is explicitly post-M1: recovery implementation, rollback rules, and broader browser-native adapter decisions
 
 ## Execution Rules
 
@@ -339,8 +340,8 @@ No new implementation slice is assigned on this branch.
 
 Current focus:
 
-- keep M1 open until W10 delivers the missing real client surface
-- keep non-M1 foundational work queued, but do not let it replace the missing real-client milestone work
+- keep M1 closed and avoid reintroducing hidden milestone scope
+- move the queue forward through recovery implementation, rollback rules, and next-milestone definition
 
 ## Queued Tasks
 
@@ -352,7 +353,7 @@ Owner:
 
 Status:
 
-- todo
+- completed (`refs #22`)
 
 Write scope:
 
@@ -363,6 +364,12 @@ Write scope:
 Output:
 
 - a navigable client surface where a user can identify, save one secret, lock or reload, and read it back
+
+Outcome:
+
+- `apps/web` now ships a local server-rendered client surface with real routes for identify, unlock, save, lock, and reopen
+- the local web client persists account config, collection head, replayable events, item records, and encrypted secret material on disk
+- the local web client uses the accepted account-scoped Argon2id plus AES-256-GCM unlock contract rather than inventing a second web-only unlock format
 
 Dependencies:
 


### PR DESCRIPTION
Refs #22
Refs #1

## Summary
- add a local server-rendered web client surface for the M1 identify/unlock/save/lock/reopen flow
- persist account-local runtime files and encrypted secret material under the accepted Argon2id + AES-256-GCM unlock contract
- update repo planning docs to mark W10 and M1 complete

## Verification
- `npm test --prefix apps/web`
- `GOCACHE=/tmp/go-build go test ./...`

## Remaining environment gap
- `npm run check --prefix apps/web` fails here because `tsc` is not installed on `PATH`