### PR TITLE
docs(plan): freeze mutable metadata rollback rules

### DIFF
--- a/docs/architecture/PROTOCOL.md
+++ b/docs/architecture/PROTOCOL.md
@@ -27,15 +27,17 @@ The following record types require canonical serialization and authenticated ver
 ## Signers
 
 - Device keys sign event records.
-- Account-level trust material authenticates account config and mutable account metadata.
+- Account-level trust material authenticates account config, snapshot pointers, device metadata, membership state, and invite state.
+- Head pointers are authenticated by the device key that authored the committed event they reference.
 - Membership and invite transitions must be authenticated by an authorized writer and validated by recipients.
 
-Exact key ownership and verification rules must be finalized before code generation or schema freezing.
+Clients must reject unsigned or unverifiable mutable metadata. This is a blocking protocol rule, not an optional diagnostic.
 
 ## Rollback Rules
 
-- Every client stores the highest trusted head it has seen for an account and relevant shared collections.
+- Every client stores the highest trusted version, cursor, or sequence it has accepted for each rollback-sensitive mutable record family.
 - Clients reject older authenticated mutable state unless explicitly recovering from a known-safe local reset flow.
+- If two authenticated mutable records claim the same trusted counter or cursor but differ in authenticated contents, clients reject the candidate as divergence.
 - Snapshots are valid only if their base cursor and authenticated metadata match the trusted event history.
 
 ## Capability Rules

--- a/docs/architecture/SYSTEM_DESIGN.md
+++ b/docs/architecture/SYSTEM_DESIGN.md
@@ -182,7 +182,7 @@ This is preferable to deriving every level from the password directly. The passw
 - Symmetric encryption: AES-256-GCM or XChaCha20-Poly1305
 - Key wrapping: AEAD-based wrapping using random nonces
 - Hashing: SHA-256 or BLAKE2/BLAKE3 for integrity metadata
-- Public-key crypto for invites and device bootstrap: X25519 for key agreement, Ed25519 for signatures if signatures are needed
+- Public-key crypto for invites and device bootstrap: X25519 for key agreement, Ed25519 for required mutable-metadata and event signatures
 
 The implementation should standardize on one primitive set across all clients. Mixing algorithms by platform creates migration and audit risk.
 
@@ -451,7 +451,7 @@ This means the mutable head pointer is the commit point. Immutable objects may e
 - A committed event must reference only immutable objects that already exist
 - Writers must be able to detect whether a retried mutation already committed by matching on idempotency key
 - Clients must reject unsigned or stale mutable metadata
-- Head pointers, account config, membership state, and snapshot pointers must be rollback-detectable
+- Head pointers, account config, snapshot pointers, device metadata, membership state, and invite state must be rollback-detectable
 
 ### Snapshot Policy
 

--- a/docs/project/DECISIONS.md
+++ b/docs/project/DECISIONS.md
@@ -338,6 +338,42 @@ Refs:
 
 - `#22`
 
+### D11 - Signed mutable metadata is a mandatory trust boundary
+
+Status:
+
+- accepted
+
+Date:
+
+- 2026-04-05
+
+Owner:
+
+- Engineer1
+
+Decision:
+
+- account config, collection head pointers, snapshot pointers, device metadata, membership state, and invite state are mandatory authenticated mutable metadata
+- clients must verify canonical bytes plus signer ownership and monotonic freshness for those records before they trust referenced immutable state
+- stale, divergent, or unsigned mutable metadata is rejected as an integrity failure, not accepted with a warning or repaired heuristically
+
+Rationale:
+
+- the security review already identifies mutable metadata rollback as the main integrity risk after the local-runtime milestone
+- the repo has canonical account and head records plus monotonic head checks, but the project docs had not yet frozen the broader signer and freshness contract for sync-critical mutable state
+- freezing the trust boundary now lets later sync, sharing, and multi-device work build against one rule instead of each slice inventing its own rollback semantics
+
+Downstream impact:
+
+- future sync work must treat mutable metadata verification as blocking behavior before event replay or snapshot restore
+- device enrollment, membership, and invite flows must bind the exact account or device identities they authorize and must reject replay to earlier trusted states
+- protocol and test-vector work should add authenticated record fixtures and stale-state rejection cases rather than relying on control-plane honesty
+
+Refs:
+
+- `#18`
+
 ## Open Questions
 
 ### P3 - Web local runtime storage boundary

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -379,3 +379,32 @@ Next action:
 
 - close issue `#22` and milestone issue `#1`
 - keep W8 and W9 explicit as post-M1 follow-up work
+
+### 2026-04-05 - Engineer1 internal note (W9)
+
+Task:
+
+- `W9 - Freeze signed mutable metadata and rollback rules`
+
+Status:
+
+- completed; refs #18
+
+Files touched:
+
+- `docs/project/INTERFACES.md`
+- `docs/project/DECISIONS.md`
+- `docs/project/HANDOFFS.md`
+- `docs/project/WORKBOARD.md`
+- `docs/architecture/PROTOCOL.md`
+- `docs/architecture/SYSTEM_DESIGN.md`
+
+Contract updates:
+
+- froze the mutable metadata families that are mandatory trust anchors: account config, collection heads, snapshot pointers, device metadata, membership state, and invite state
+- froze signer ownership, required scope bindings, and monotonic freshness rules for those records
+- required clients to reject stale, divergent, or unsigned mutable metadata before replay, snapshot restore, or authorization-sensitive state transitions
+
+Next action:
+
+- future sync and sharing implementation should add authenticated record envelopes and stale-state rejection tests against the frozen W9 contract

--- a/docs/project/INTERFACES.md
+++ b/docs/project/INTERFACES.md
@@ -289,6 +289,88 @@ Fields:
 - server-assisted recovery escrow
 - device enrollment via recovery key (separate protocol slice)
 
+## I7 - Signed Mutable Metadata and Rollback Contract
+
+Status:
+
+- accepted
+
+Owner:
+
+- Engineer1
+
+Frozen for W9 (`refs #18`):
+
+Goals:
+
+- freeze which mutable records are security-relevant trust anchors
+- define who authenticates each mutable record family
+- require freshness and rollback checks before a client trusts mutable state from storage or the control plane
+
+Mutable record families in scope:
+
+- account config
+- collection head pointers
+- snapshot pointers
+- device metadata
+- membership state
+- invite state
+
+Out of scope for I7:
+
+- the exact binary or JSON envelope used to carry signatures
+- control-plane storage schema
+- share-protocol implementation details beyond the trust checks consumers must enforce
+
+### Canonicalization and Authentication
+
+- every record family in scope must have canonical bytes before hashing or signing
+- clients must authenticate canonical bytes, not transport formatting, pretty-printed JSON, or field order as received
+- unsigned mutable metadata is invalid; clients must reject it rather than downgrade to best-effort replay
+- signature or MAC verification failures are hard failures, not telemetry-only warnings
+
+### Signer Ownership
+
+- account config is authenticated by account-level trust material
+- collection head pointers are authenticated by the device signing key that authored the committed event referenced by the head
+- snapshot pointers are authenticated by account-level trust material and must bind the referenced snapshot object plus the base event cursor
+- device metadata is authenticated by account-level trust material; device self-assertion alone is insufficient
+- membership state is authenticated by account-level trust material for collection-owner decisions
+- invite state is authenticated by account-level trust material for lifecycle transitions and must bind the intended recipient account and recipient device key when accepted
+
+### Required Binding Fields
+
+- every mutable record must bind `accountId`
+- collection-scoped mutable records must bind `collectionId`
+- device-scoped mutable records must bind `deviceId`
+- head pointers must bind `latestEventId` and the monotonic event cursor or sequence they advance to
+- snapshot pointers must bind the snapshot object identifier plus the event cursor the snapshot represents
+- membership and invite records must bind the member or recipient account identity and any recipient device key material they authorize
+
+### Freshness and Rollback Rules
+
+- clients must persist the highest trusted version of each mutable record family they have accepted
+- a candidate mutable record with a lower trusted counter, cursor, or version than the local trusted value is stale and must be rejected
+- if a candidate record presents the same trusted counter, cursor, or version but different authenticated contents, clients must reject it as a divergence attempt
+- clients may only clear trusted rollback state through an explicit local reset or account-recovery flow; ordinary restart, logout, or cache eviction must not erase trusted high-water marks
+- compare-and-swap success at the storage layer is necessary for writes but not sufficient for reads; readers must still verify signatures and monotonicity locally
+
+### Record-Specific Freshness Requirements
+
+- account config must advance monotonically whenever device membership, default collection wiring, or other security-relevant account metadata changes
+- collection head pointers must advance monotonically by event sequence or cursor; equal-sequence candidates are valid only when the authenticated `latestEventId` also matches
+- snapshot pointers must not move to an older base cursor than the highest trusted snapshot or committed head for the same scope
+- device metadata must reject removed or downgraded device state unless the change is authenticated by current account-level trust material
+- membership state must reject stale active or stale revoked states; revocation is forward-looking but rollback to pre-revocation metadata is invalid
+- invite state must reject replay to an earlier lifecycle state once acceptance, expiry, or revocation has been trusted
+
+### Consumer Behavior
+
+- clients must fetch mutable metadata before trusting referenced immutable objects
+- clients must verify the signer, scope bindings, and freshness of mutable metadata before applying events, snapshots, memberships, or invites
+- unreachable immutable objects that are not referenced by the latest trusted mutable metadata must not become authoritative
+- if mutable metadata verification fails, clients must stop the affected sync or access flow and surface an integrity failure instead of silently repairing state
+
 ## I5 - Handoff Protocol
 
 Status:

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -387,7 +387,7 @@ Owner:
 
 Status:
 
-- in progress (`refs #20`)
+- completed (`refs #20`)
 
 Write scope:
 
@@ -445,7 +445,7 @@ Owner:
 
 Status:
 
-- todo (`refs #18`)
+- completed (`refs #18`)
 
 Write scope:
 


### PR DESCRIPTION
Refs #18

## Summary
- freeze the signed mutable-metadata contract in `docs/project/INTERFACES.md`
- record the mandatory trust-boundary decision in `docs/project/DECISIONS.md`
- align protocol and system-design wording with the accepted signer and rollback rules
- close repo-doc status drift for W7 and W9 in `docs/project/WORKBOARD.md`

## Verification
- reviewed the resulting doc diff for consistency against the repo's existing canonical account-config, head, and monotonic-head semantics

## Write scope
- docs/project/INTERFACES.md
- docs/project/DECISIONS.md
- docs/project/HANDOFFS.md
- docs/project/WORKBOARD.md
- docs/architecture/PROTOCOL.md
- docs/architecture/SYSTEM_DESIGN.md