### PR TITLE
docs(plan): freeze M2 sync foundation scope

### DIFF
--- a/docs/project/DECISIONS.md
+++ b/docs/project/DECISIONS.md
@@ -374,6 +374,43 @@ Refs:
 
 - `#18`
 
+### D12 - Post-M1 execution moves to multi-device single-user sync foundations
+
+Status:
+
+- accepted
+
+Date:
+
+- 2026-04-06
+
+Owner:
+
+- Engineer1
+
+Decision:
+
+- the next milestone after M1 is `M2 - Multi-Device Single-User Sync Foundations`
+- M2 prioritizes signed mutable-metadata verification in code, device-enrollment contracts and primitives, object-store sync, and the narrow control-plane path needed to prove two-device single-user sync
+- browser-native adapter redesign, multi-user sharing, and broad web-product polish stay out of the critical path until the two-device sync proof exists
+
+Rationale:
+
+- M1 is closed, so the next highest-risk gap is not another local-runtime surface change; it is whether Safe can move from one trusted device to two without losing integrity guarantees
+- the security and implementation docs both identify rollback protection, device enrollment, and object-store sync as the hard blockers between a local demo and a real zero-knowledge product
+- keeping browser-adapter work and broader UX polish explicitly deferred prevents the team from rebuilding surface area before the sync and trust model is proven
+
+Downstream impact:
+
+- W11-W17 become the active queue under milestone issue `#30`
+- W12 and W13 are contract and trust-boundary gates for downstream implementation work
+- future planning should treat browser-native storage questions as a follow-up stream, not as grounds to dilute M2 acceptance
+
+Refs:
+
+- `#30`
+- `#31`
+
 ## Open Questions
 
 ### P3 - Web local runtime storage boundary

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -408,3 +408,98 @@ Contract updates:
 Next action:
 
 - future sync and sharing implementation should add authenticated record envelopes and stale-state rejection tests against the frozen W9 contract
+
+### 2026-04-06 - Engineer1 internal note (M2 planning reset)
+
+Task:
+
+- `M2 - Multi-Device Single-User Sync Foundations`
+
+Status:
+
+- planned (`refs #30`)
+
+Files touched:
+
+- `docs/project/WORKBOARD.md`
+- `docs/project/DECISIONS.md`
+- `docs/project/HANDOFFS.md`
+
+Next action:
+
+- move the board from closed M1 work to the explicit M2 queue and keep browser-native adapter work out of the critical path until two-device sync is proven
+
+### 2026-04-06 - Engineer1 to Engineer1
+
+Task:
+
+- `W11 - Freeze M2 sync-foundation scope and acceptance`
+- `W12 - Implement signed mutable-metadata verification in code`
+- `W13 - Freeze device-enrollment contract for account recovery and new devices`
+
+Status:
+
+- assigned (`refs #31`, `#36`, `#35`)
+
+Write scope:
+
+- `docs/project/**`
+- `docs/architecture/IMPLEMENTATION_PLAN.md` for wording alignment only
+- `docs/architecture/PROTOCOL.md` and `docs/architecture/SYSTEM_DESIGN.md` for contract alignment only
+- `internal/sync/**`
+- `internal/domain/**` if authenticated-record types are needed
+- `packages/test-vectors/**` if shared fixtures are needed
+
+Next action:
+
+- freeze the M2 acceptance boundary first, then land signed mutable-metadata verification and the device-enrollment contract before downstream sync or client wiring starts
+
+### 2026-04-06 - Engineer1 to Engineer2
+
+Task:
+
+- `W14 - Implement device-enrollment primitives and persisted tests`
+- `W15 - Implement account-path object-store sync and commit protocol`
+
+Status:
+
+- planned; pending assignment acceptance (`refs #34`, `#33`)
+
+Write scope:
+
+- `internal/crypto/**`
+- `internal/domain/**` for enrollment records
+- `internal/sync/**`
+- `internal/storage/**` if the object-store adapter boundary needs expansion
+- `packages/test-vectors/**` if shared fixtures are needed
+
+Do not edit:
+
+- `apps/web/**`
+- `cmd/safe/**`
+- `cmd/control-plane/**`
+- `internal/auth/**`
+
+Next action:
+
+- wait for W12 and W13 to freeze the verification and enrollment boundaries, then implement the persisted enrollment and account-path sync slices against those contracts
+
+### 2026-04-06 - Engineer1 completion note (W11)
+
+Task:
+
+- `W11 - Freeze M2 sync-foundation scope and acceptance`
+
+Status:
+
+- completed; refs #31
+
+Files touched:
+
+- `docs/project/WORKBOARD.md`
+- `docs/project/DECISIONS.md`
+- `docs/project/HANDOFFS.md`
+
+Next action:
+
+- carry the M2 planning reset through GitHub project status and issue updates, then start W12 and W13 against the accepted M2 boundary

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -28,39 +28,37 @@ Important:
 
 ## Current Milestone
 
-Milestone: `M1 - First Trustworthy Local Loop`
+Milestone: `M2 - Multi-Device Single-User Sync Foundations`
 
 GitHub issue:
 
-- `#1`
+- `#30`
 
 Goal:
 
-- a user can identify into a real client surface
-- unlock local state with a real password-derived path
-- save one secret into durable encrypted local storage
-- close or lock the client
-- reopen or unlock and read that secret back
+- two trusted devices can converge on one account through a real object-storage sync path
+- clients verify signed mutable metadata and reject stale or replayed state before trusting it
+- device enrollment requires existing-device approval or recovery-key bootstrap
+- the shipped clients can prove the account loop across two devices, not only one local runtime
 
 Current status:
 
-- CLI local-runtime save or read is shipped and test-backed
-- a local server-rendered web client now ships in `apps/web` and completes the same identify, unlock, save, lock, and reopen loop
-- M1 is complete on `main`; remaining work is post-M1 hardening and expansion, not a hidden milestone gap
+- M1 remains complete on `main`; the CLI and local web client already close the first trustworthy local loop (`refs #1`, `#22`)
+- post-M1 groundwork is in place: recovery-key wrap and unwrap shipped in code (`refs #19`) and rollback rules are now frozen as a contract (`refs #18`)
+- M2 planning is now live in GitHub and in repo docs; no M2 implementation slice has landed yet (`refs #30`, `#31`, `#32`, `#33`, `#34`, `#35`, `#36`, `#37`)
 
 Non-goals for this milestone:
 
-- sharing
-- invites
-- multi-device sync
-- OAuth production hardening
-- rich vault UX beyond what is needed to prove the loop
+- multi-user sharing and revocation
+- browser-native adapter redesign
+- broad web-product UX polish beyond the sync proof path
+- OAuth production hardening beyond the narrow control-plane access path needed for single-account sync
 
-Milestone closeout status:
+Milestone kickoff status:
 
-- implementation slices W1-W7 and W10 are complete (`refs #2`, `#3`, `#4`, `#5`, `#6`, `#20`, `#22`)
-- the first trustworthy local loop is now closed for both the CLI and the local web client (`refs #1`)
-- remaining queued work is explicitly post-M1: recovery implementation, rollback rules, and broader browser-native adapter decisions
+- W11 defines the M2 boundary and closes the planning reset (`refs #31`)
+- W12, W13, and W15 are the critical-path contract and implementation slices for sync integrity (`refs #36`, `#35`, `#33`)
+- W14, W16, and W17 stay explicit downstream tasks rather than hidden scope (`refs #34`, `#32`, `#37`)
 
 ## Execution Rules
 
@@ -92,11 +90,13 @@ Current owner:
 
 Role:
 
-- implementation owner for the first durable local runtime slice
+- implementation owner for crypto and sync-heavy implementation slices
 
 Status:
 
-- W2 complete (`refs #4`); W4 merged (`refs #3`); W7 in progress (`refs #20`)
+- W2 complete (`refs #4`)
+- W8 complete (`refs #19`)
+- W14 and W15 queued for M2 (`refs #34`, `#33`)
 
 Current owner:
 
@@ -334,18 +334,7 @@ GitHub issue:
 
 - `#21`
 
-## Next Assignment
-
-No new implementation slice is assigned on this branch.
-
-Current focus:
-
-- keep M1 closed and avoid reintroducing hidden milestone scope
-- move the queue forward through recovery implementation, rollback rules, and next-milestone definition
-
-## Queued Tasks
-
-### W10 - Deliver a real M1 client surface
+### W11 - Freeze M2 sync-foundation scope and acceptance
 
 Owner:
 
@@ -353,62 +342,101 @@ Owner:
 
 Status:
 
-- completed (`refs #22`)
+- completed (`refs #31`)
 
 Write scope:
 
-- `apps/web/**`
-- `cmd/control-plane/**` if the client surface needs the existing dev identity bootstrap path
-- minimal doc updates in `docs/project/**` if the surface contract changes
+- `docs/project/WORKBOARD.md`
+- `docs/project/DECISIONS.md`
+- `docs/project/HANDOFFS.md`
+- minimal alignment notes in `docs/architecture/IMPLEMENTATION_PLAN.md` if wording drifts
 
 Output:
 
-- a navigable client surface where a user can identify, save one secret, lock or reload, and read it back
-
-Outcome:
-
-- `apps/web` now ships a local server-rendered client surface with real routes for identify, unlock, save, lock, and reopen
-- the local web client persists account config, collection head, replayable events, item records, and encrypted secret material on disk
-- the local web client uses the accepted account-scoped Argon2id plus AES-256-GCM unlock contract rather than inventing a second web-only unlock format
+- explicit M2 milestone boundary, acceptance checks, and deferred-work list
 
 Dependencies:
 
-- W5
+- M2 milestone issue `#30`
 
 GitHub issue:
 
-- `#22`
+- `#31`
 
-### W7 - Freeze recovery-key account contract
+### W12 - Implement signed mutable-metadata verification in code
 
 Owner:
 
-- Engineer2 (Claude), cross-boundary per D3
+- Engineer1
 
 Status:
 
-- completed (`refs #20`)
+- planned (`refs #36`)
+
+Write scope:
+
+- `internal/sync/**`
+- `internal/domain/**` if shared authenticated-record types are required
+- `packages/test-vectors/**` if shared fixtures are needed
+- narrow contract clarifications only in `docs/project/**`
+
+Output:
+
+- one verification path for signed mutable metadata plus stale-state rejection tests
+
+Dependencies:
+
+- W9
+- W11
+
+GitHub issue:
+
+- `#36`
+
+### W13 - Freeze device-enrollment contract for account recovery and new devices
+
+Owner:
+
+- Engineer1
+
+Status:
+
+- planned (`refs #35`)
 
 Write scope:
 
 - `docs/project/INTERFACES.md`
 - `docs/project/DECISIONS.md`
 - `docs/project/HANDOFFS.md`
+- alignment-only notes in `docs/architecture/SYSTEM_DESIGN.md` and `docs/architecture/PROTOCOL.md` if needed
 
 Output:
 
-- frozen persisted recovery-key contract for account bootstrap and account recovery
+- frozen contract for existing-device approval and recovery-key bootstrap
 
 Dependencies:
 
-- W1
-- W3
+- W8
+- W9
+- W11
 
 GitHub issue:
 
-- `#20`
+- `#35`
 
-### W8 - Implement recovery-key wrap and recovery tests
+## Next Assignment
+
+The next implementation wave is now defined and on the board.
+
+Current focus:
+
+- merge W11 so the repo workboard, decisions log, and GitHub project stay aligned on M2
+- treat W12 and W13 as the contract and integrity gates before downstream sync or client wiring
+- keep browser-native adapter work explicitly deferred until the two-device sync proof exists
+
+## Queued Tasks
+
+### W14 - Implement device-enrollment primitives and persisted tests
 
 Owner:
 
@@ -416,28 +444,57 @@ Owner:
 
 Status:
 
-- completed (`refs #19`)
+- planned (`refs #34`)
 
 Write scope:
 
 - `internal/crypto/**`
-- supporting account-domain records if required
-- test vectors or fixtures if needed
+- `internal/domain/**` for enrollment records
+- `packages/test-vectors/**` if cross-runtime fixtures are required
 
 Output:
 
-- recovery-key generation plus AMK wrap and unwrap support
-- persisted-account recovery tests and wrong-key or corrupted-payload coverage
+- device-enrollment primitives plus persisted success and failure tests
 
 Dependencies:
 
-- W7
+- W13
+- W8
 
 GitHub issue:
 
-- `#19`
+- `#34`
 
-### W9 - Freeze signed mutable metadata and rollback rules
+### W15 - Implement account-path object-store sync and commit protocol
+
+Owner:
+
+- Engineer2
+
+Status:
+
+- planned (`refs #33`)
+
+Write scope:
+
+- `internal/sync/**`
+- `internal/storage/**` if the object-store adapter boundary needs expansion
+- `packages/test-vectors/**` if integration fixtures are needed
+
+Output:
+
+- single-user object-store sync path with explicit commit semantics and stale-head rejection
+
+Dependencies:
+
+- W12
+- W11
+
+GitHub issue:
+
+- `#33`
+
+### W16 - Implement minimal control-plane access mediation for single-account sync
 
 Owner:
 
@@ -445,34 +502,66 @@ Owner:
 
 Status:
 
-- completed (`refs #18`)
+- planned (`refs #32`)
 
 Write scope:
 
-- `docs/project/INTERFACES.md`
-- `docs/project/DECISIONS.md`
-- `docs/project/HANDOFFS.md`
-- architecture notes only where wording needs alignment
+- `cmd/control-plane/**`
+- `internal/auth/**`
+- integration tests only where required
 
 Output:
 
-- frozen contract for signed mutable metadata, freshness checks, and rollback-sensitive objects
+- narrow account-scoped object-access path for single-user sync
 
 Dependencies:
 
-- W1
+- W11
+- W13
 
 GitHub issue:
 
-- `#18`
+- `#32`
+
+### W17 - Deliver a two-device single-user sync smoke path
+
+Owner:
+
+- Engineer1
+
+Status:
+
+- planned (`refs #37`)
+
+Write scope:
+
+- `apps/web/**`
+- `cmd/safe/**`
+- `docs/project/**` for milestone closeout only if needed
+
+Output:
+
+- reproducible two-device sync proof through the shipped clients
+
+Dependencies:
+
+- W14
+- W15
+- W16
+
+GitHub issue:
+
+- `#37`
 
 ## Merge Order
 
-1. W1 contract docs
-2. W2 persistence adapter
-3. W3 crypto primitives
-4. W4 CLI integration
-5. W5 web integration
+1. W11 planning reset
+2. W12 signed-metadata verification
+3. W13 device-enrollment contract
+4. W14 enrollment primitives
+5. W15 object-store sync and commit protocol
+6. W16 control-plane access mediation
+7. W17 two-device smoke path
 
 ## PR Template
 


### PR DESCRIPTION
Refs #31

## Summary
- reset the repo planning docs from closed M1 work to the explicit M2 queue
- record the accepted M2 execution decision and the W11-W17 sequencing
- add the W11 completion handoff and keep W14/W15 queued behind W12/W13

## Verification
- reviewed the doc diffs against the live GitHub milestone and issue set
- confirmed main was current with origin/main before branching