### PR TITLE
feat(sync): verify signed mutable metadata

### DIFF
--- a/internal/sync/authenticated.go
+++ b/internal/sync/authenticated.go
@@ -1,0 +1,207 @@
+package sync
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ndelorme/safe/internal/domain"
+)
+
+type SignedAccountConfig struct {
+	Version   int
+	Record    domain.AccountConfigRecord
+	Signature string
+}
+
+type SignedCollectionHead struct {
+	Record    domain.CollectionHeadRecord
+	Signature string
+}
+
+func VerifySignedAccountConfig(candidate SignedAccountConfig, trusted *SignedAccountConfig, accountPublicKey ed25519.PublicKey) error {
+	candidatePayload, err := candidate.canonicalPayload()
+	if err != nil {
+		return err
+	}
+
+	signature, err := decodeSignature(candidate.Signature)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(accountPublicKey, candidatePayload, signature) {
+		return ErrMutableMetadataSignature("accountConfig")
+	}
+
+	if trusted == nil {
+		return nil
+	}
+
+	if trusted.Record.AccountID != candidate.Record.AccountID {
+		return ErrReplayInvariant("accountConfig.accountId")
+	}
+	if candidate.Version < trusted.Version {
+		return ErrStaleMutableMetadata("accountConfig", trusted.Version, candidate.Version)
+	}
+
+	if candidate.Version == trusted.Version {
+		trustedPayload, err := trusted.canonicalPayload()
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(trustedPayload, candidatePayload) {
+			return ErrDivergentMutableMetadata("accountConfig", candidate.Version)
+		}
+	}
+
+	return nil
+}
+
+func VerifySignedCollectionHead(candidate SignedCollectionHead, trusted *SignedCollectionHead, latestEvent domain.VaultEventRecord, authoringDevice domain.LocalDeviceRecord) error {
+	candidatePayload, err := candidate.canonicalPayload()
+	if err != nil {
+		return err
+	}
+	if err := latestEvent.Validate(); err != nil {
+		return err
+	}
+	if err := authoringDevice.Validate(); err != nil {
+		return err
+	}
+	if authoringDevice.Status != "active" {
+		return ErrReplayInvariant("device.status")
+	}
+	if latestEvent.AccountID != candidate.Record.AccountID {
+		return ErrReplayInvariant("event.accountId")
+	}
+	if latestEvent.CollectionID != candidate.Record.CollectionID {
+		return ErrReplayInvariant("event.collectionId")
+	}
+	if latestEvent.EventID != candidate.Record.LatestEventID {
+		return ErrReplayInvariant("head.latestEventId")
+	}
+	if latestEvent.Sequence != candidate.Record.LatestSeq {
+		return ErrHeadMismatch("latestSeq", candidate.Record.LatestSeq, latestEvent.Sequence)
+	}
+	if authoringDevice.AccountID != candidate.Record.AccountID {
+		return ErrReplayInvariant("device.accountId")
+	}
+	if authoringDevice.DeviceID != latestEvent.DeviceID {
+		return ErrReplayInvariant("device.deviceId")
+	}
+
+	signingPublicKey, err := decodeDeviceSigningKey(authoringDevice.SigningPublicKey)
+	if err != nil {
+		return err
+	}
+	signature, err := decodeSignature(candidate.Signature)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(signingPublicKey, candidatePayload, signature) {
+		return ErrMutableMetadataSignature("collectionHead")
+	}
+
+	if trusted == nil {
+		return nil
+	}
+	return EnsureMonotonicHead(trusted.Record, candidate.Record)
+}
+
+func (record SignedAccountConfig) canonicalPayload() ([]byte, error) {
+	if record.Version < 1 {
+		return nil, ErrReplayInvariant("accountConfig.version")
+	}
+	accountJSON, err := record.Record.CanonicalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	type canonicalSignedAccountConfig struct {
+		Version int             `json:"version"`
+		Record  json.RawMessage `json:"record"`
+	}
+
+	return json.Marshal(canonicalSignedAccountConfig{
+		Version: record.Version,
+		Record:  accountJSON,
+	})
+}
+
+func (record SignedCollectionHead) canonicalPayload() ([]byte, error) {
+	return record.Record.CanonicalJSON()
+}
+
+func decodeSignature(signature string) ([]byte, error) {
+	if signature == "" {
+		return nil, ErrUnsignedMutableMetadata("signature")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(signature)
+	if err != nil {
+		return nil, ErrUnsignedMutableMetadata("signature")
+	}
+	if len(decoded) != ed25519.SignatureSize {
+		return nil, ErrUnsignedMutableMetadata("signature")
+	}
+	return decoded, nil
+}
+
+func decodeDeviceSigningKey(value string) (ed25519.PublicKey, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return nil, ErrReplayInvariant("device.signingPublicKey")
+	}
+	if len(decoded) != ed25519.PublicKeySize {
+		return nil, ErrReplayInvariant("device.signingPublicKey")
+	}
+	return ed25519.PublicKey(decoded), nil
+}
+
+type unsignedMutableMetadataError string
+
+func (err unsignedMutableMetadataError) Error() string {
+	return fmt.Sprintf("unsigned mutable metadata rejected: %s", string(err))
+}
+
+func ErrUnsignedMutableMetadata(field string) error {
+	return unsignedMutableMetadataError(field)
+}
+
+type mutableMetadataSignatureError string
+
+func (err mutableMetadataSignatureError) Error() string {
+	return fmt.Sprintf("mutable metadata signature verification failed: %s", string(err))
+}
+
+func ErrMutableMetadataSignature(family string) error {
+	return mutableMetadataSignatureError(family)
+}
+
+type staleMutableMetadataError struct {
+	family    string
+	trusted   int
+	candidate int
+}
+
+func (err staleMutableMetadataError) Error() string {
+	return fmt.Sprintf("stale mutable metadata rejected: %s trusted %d candidate %d", err.family, err.trusted, err.candidate)
+}
+
+func ErrStaleMutableMetadata(family string, trusted, candidate int) error {
+	return staleMutableMetadataError{family: family, trusted: trusted, candidate: candidate}
+}
+
+type divergentMutableMetadataError struct {
+	family  string
+	version int
+}
+
+func (err divergentMutableMetadataError) Error() string {
+	return fmt.Sprintf("divergent mutable metadata rejected: %s version %d", err.family, err.version)
+}
+
+func ErrDivergentMutableMetadata(family string, version int) error {
+	return divergentMutableMetadataError{family: family, version: version}
+}

--- a/internal/sync/authenticated_test.go
+++ b/internal/sync/authenticated_test.go
@@ -1,0 +1,191 @@
+package sync
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	internalcrypto "github.com/ndelorme/safe/internal/crypto"
+	"github.com/ndelorme/safe/internal/domain"
+)
+
+func TestVerifySignedAccountConfigAcceptsValidSignature(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	candidate := mustSignAccountConfig(t, privateKey, domain.StarterAccountConfigRecord(), 2)
+
+	if err := VerifySignedAccountConfig(candidate, nil, publicKey); err != nil {
+		t.Fatalf("verify signed account config: %v", err)
+	}
+}
+
+func TestVerifySignedAccountConfigRejectsUnsignedMetadata(t *testing.T) {
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	candidate := SignedAccountConfig{
+		Version: 1,
+		Record:  domain.StarterAccountConfigRecord(),
+	}
+
+	if err := VerifySignedAccountConfig(candidate, nil, publicKey); err == nil {
+		t.Fatal("expected unsigned metadata rejection")
+	}
+}
+
+func TestVerifySignedAccountConfigRejectsRollback(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	trusted := mustSignAccountConfig(t, privateKey, domain.StarterAccountConfigRecord(), 3)
+	candidate := mustSignAccountConfig(t, privateKey, domain.StarterAccountConfigRecord(), 2)
+
+	if err := VerifySignedAccountConfig(candidate, &trusted, publicKey); err == nil {
+		t.Fatal("expected stale metadata rejection")
+	}
+}
+
+func TestVerifySignedAccountConfigRejectsDivergenceAtSameVersion(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	trusted := mustSignAccountConfig(t, privateKey, domain.StarterAccountConfigRecord(), 4)
+	candidateRecord := domain.StarterAccountConfigRecord()
+	candidateRecord.DefaultCollectionID = "vault-rotated"
+	candidateRecord.CollectionIDs = []string{"vault-personal", "vault-rotated"}
+	candidate := mustSignAccountConfig(t, privateKey, candidateRecord, 4)
+
+	if err := VerifySignedAccountConfig(candidate, &trusted, publicKey); err == nil {
+		t.Fatal("expected divergence rejection")
+	}
+}
+
+func TestVerifySignedCollectionHeadAcceptsValidSignature(t *testing.T) {
+	keyPair, err := internalcrypto.GenerateDeviceKeyPair()
+	if err != nil {
+		t.Fatalf("generate device key pair: %v", err)
+	}
+
+	event := domain.StarterVaultEventRecords()[1]
+	head := domain.StarterCollectionHeadRecord()
+	deviceRecord, err := internalcrypto.CreateDeviceRecord(event.AccountID, event.DeviceID, "Primary laptop", "cli", keyPair)
+	if err != nil {
+		t.Fatalf("create device record: %v", err)
+	}
+
+	candidate := mustSignCollectionHead(t, keyPair.SigningPrivateKey, head)
+	if err := VerifySignedCollectionHead(candidate, nil, event, deviceRecord); err != nil {
+		t.Fatalf("verify signed collection head: %v", err)
+	}
+}
+
+func TestVerifySignedCollectionHeadRejectsWrongAuthoringDevice(t *testing.T) {
+	keyPair, err := internalcrypto.GenerateDeviceKeyPair()
+	if err != nil {
+		t.Fatalf("generate device key pair: %v", err)
+	}
+
+	event := domain.StarterVaultEventRecords()[1]
+	head := domain.StarterCollectionHeadRecord()
+	deviceRecord, err := internalcrypto.CreateDeviceRecord(event.AccountID, "dev-other-001", "Secondary laptop", "cli", keyPair)
+	if err != nil {
+		t.Fatalf("create device record: %v", err)
+	}
+
+	candidate := mustSignCollectionHead(t, keyPair.SigningPrivateKey, head)
+	if err := VerifySignedCollectionHead(candidate, nil, event, deviceRecord); err == nil {
+		t.Fatal("expected authoring-device binding rejection")
+	}
+}
+
+func TestVerifySignedCollectionHeadRejectsBadSignature(t *testing.T) {
+	keyPair, err := internalcrypto.GenerateDeviceKeyPair()
+	if err != nil {
+		t.Fatalf("generate device key pair: %v", err)
+	}
+
+	otherPublic, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate unrelated key: %v", err)
+	}
+
+	event := domain.StarterVaultEventRecords()[1]
+	head := domain.StarterCollectionHeadRecord()
+	deviceRecord, err := internalcrypto.CreateDeviceRecord(event.AccountID, event.DeviceID, "Primary laptop", "cli", keyPair)
+	if err != nil {
+		t.Fatalf("create device record: %v", err)
+	}
+	deviceRecord.SigningPublicKey = base64.RawURLEncoding.EncodeToString(otherPublic)
+
+	candidate := mustSignCollectionHead(t, keyPair.SigningPrivateKey, head)
+	if err := VerifySignedCollectionHead(candidate, nil, event, deviceRecord); err == nil {
+		t.Fatal("expected signature failure")
+	}
+}
+
+func TestVerifySignedCollectionHeadRejectsRollback(t *testing.T) {
+	keyPair, err := internalcrypto.GenerateDeviceKeyPair()
+	if err != nil {
+		t.Fatalf("generate device key pair: %v", err)
+	}
+
+	events := domain.StarterVaultEventRecords()
+	event := events[1]
+	trustedHead := domain.CollectionHeadRecord{
+		SchemaVersion: 1,
+		AccountID:     event.AccountID,
+		CollectionID:  event.CollectionID,
+		LatestEventID: "evt-login-github-primary-v3",
+		LatestSeq:     3,
+	}
+	deviceRecord, err := internalcrypto.CreateDeviceRecord(event.AccountID, event.DeviceID, "Primary laptop", "cli", keyPair)
+	if err != nil {
+		t.Fatalf("create device record: %v", err)
+	}
+
+	trusted := mustSignCollectionHead(t, keyPair.SigningPrivateKey, trustedHead)
+	candidate := mustSignCollectionHead(t, keyPair.SigningPrivateKey, domain.StarterCollectionHeadRecord())
+
+	if err := VerifySignedCollectionHead(candidate, &trusted, event, deviceRecord); err == nil {
+		t.Fatal("expected stale head rejection")
+	}
+}
+
+func mustSignAccountConfig(t *testing.T, privateKey ed25519.PrivateKey, record domain.AccountConfigRecord, version int) SignedAccountConfig {
+	t.Helper()
+
+	signed := SignedAccountConfig{
+		Version: version,
+		Record:  record,
+	}
+	payload, err := signed.canonicalPayload()
+	if err != nil {
+		t.Fatalf("canonical signed account config: %v", err)
+	}
+	signed.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, payload))
+	return signed
+}
+
+func mustSignCollectionHead(t *testing.T, privateKey ed25519.PrivateKey, record domain.CollectionHeadRecord) SignedCollectionHead {
+	t.Helper()
+
+	signed := SignedCollectionHead{
+		Record: record,
+	}
+	payload, err := signed.canonicalPayload()
+	if err != nil {
+		t.Fatalf("canonical signed collection head: %v", err)
+	}
+	signed.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, payload))
+	return signed
+}


### PR DESCRIPTION
Refs #36

## Summary
- add a sync-local verification path for signed account config metadata with freshness and divergence checks
- add collection-head verification that binds the signed head to the latest event and the active authoring device key
- add negative tests for unsigned metadata, bad signatures, device mismatch, rollback, and same-version divergence

## Verification
- `go test ./internal/sync/...`
- `go test ./...`