### PR TITLE
feat(sync): object-store sync and commit protocol (W15, refs #33)

### DIFF
--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -39,6 +39,36 @@ Current planning issues:
 
 ## Entries
 
+### 2026-04-06 - Engineer2 progress note (W15)
+
+Task:
+
+- `W15 - Implement account-path object-store sync and commit protocol`
+
+Status:
+
+- in progress; refs #33
+
+Files touched:
+
+- `internal/storage/cas.go` (new — ObjectStoreWithCAS interface, MemoryObjectStoreWithCAS, ErrCASConflict, ContentETag)
+- `internal/sync/writer.go` (new — SyncWriter, CommitSyncMutation with CAS head advancement)
+- `internal/sync/reader.go` (new — SyncReader, IncrementalSync)
+- `internal/sync/verify.go` (new — VerifyHeadFunc interface, MonotonicVerifyHead stub for W12 integration)
+- `internal/sync/sync_test.go` (new — 8 tests: single commit, two-runtime convergence, interrupt safety, stale head rejection, idempotent commit, CAS conflict, empty collection, delete convergence)
+- `docs/project/WORKBOARD.md`, `docs/project/HANDOFFS.md` (status updates)
+
+W12 integration note:
+
+- W15 ships with `VerifyHeadFunc` as an injectable interface (W12 integration point)
+- Default stub `MonotonicVerifyHead` passes freshness checks but does NOT verify Ed25519 signatures
+- When W12 defines the event signature envelope, inject the real verifier via `NewSyncWriter(store, w12VerifyHead)` — no W15 code changes needed
+
+Next action:
+
+- W12 signature verification integration once Engineer1 opens that branch
+- Engineer1 review of W15 before merge
+
 ### 2026-04-06 - Engineer2 cross-boundary note (W13)
 
 Task:

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -96,9 +96,9 @@ Status:
 
 - W2 complete (`refs #4`)
 - W8 complete (`refs #19`)
-- W13 cross-boundary complete, Engineer1 review pending (`refs #35`)
-- W14 in progress (`refs #34`)
-- W15 queued (`refs #33`)
+- W13 cross-boundary complete (`refs #35`)
+- W14 complete (`refs #34`)
+- W15 in progress (`refs #33`)
 
 Current owner:
 
@@ -447,7 +447,7 @@ Owner:
 
 Status:
 
-- in progress (`refs #34`)
+- completed (`refs #34`)
 
 Write scope:
 
@@ -476,7 +476,7 @@ Owner:
 
 Status:
 
-- planned (`refs #33`)
+- in progress (`refs #33`)
 
 Write scope:
 

--- a/internal/storage/cas.go
+++ b/internal/storage/cas.go
@@ -1,0 +1,118 @@
+package storage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// ErrCASConflict is returned by PutIfMatch when the stored ETag does not match
+// the expectedETag, indicating a concurrent write has advanced the object.
+var ErrCASConflict = errors.New("object store CAS conflict: ETag mismatch")
+
+// ObjectStoreWithCAS extends ObjectStore with compare-and-swap support for
+// head-pointer advancement. Immutable objects (events, items) use the base Put.
+// Only mutable head records require CAS.
+type ObjectStoreWithCAS interface {
+	ObjectStore
+
+	// GetWithETag returns the current value and its ETag. The ETag is opaque to
+	// callers; it must be passed back to PutIfMatch to prove the caller observed
+	// the same version being replaced. Returns ErrObjectNotFound if absent.
+	GetWithETag(key string) (value []byte, etag string, err error)
+
+	// PutIfMatch writes value at key only if the current ETag equals expectedETag.
+	// On success it returns the new ETag for the written value.
+	// On conflict it returns ("", ErrCASConflict).
+	// Pass expectedETag="" to signal "object must not yet exist" (create-only).
+	PutIfMatch(key string, value []byte, expectedETag string) (newETag string, err error)
+}
+
+// ContentETag returns a stable ETag for value: hex-encoded SHA-256 of the bytes.
+// This is used by MemoryObjectStoreWithCAS and can be used in tests to predict ETags.
+func ContentETag(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
+}
+
+// MemoryObjectStoreWithCAS is an in-memory ObjectStoreWithCAS suitable for
+// tests that simulate two runtimes sharing a single object store.
+type MemoryObjectStoreWithCAS struct {
+	mu      sync.Mutex
+	objects map[string]casEntry
+}
+
+type casEntry struct {
+	value []byte
+	etag  string
+}
+
+// NewMemoryObjectStoreWithCAS returns an empty in-memory CAS-capable store.
+func NewMemoryObjectStoreWithCAS() *MemoryObjectStoreWithCAS {
+	return &MemoryObjectStoreWithCAS{
+		objects: make(map[string]casEntry),
+	}
+}
+
+func (s *MemoryObjectStoreWithCAS) Put(key string, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.objects[key] = casEntry{value: append([]byte(nil), value...), etag: ContentETag(value)}
+	return nil
+}
+
+func (s *MemoryObjectStoreWithCAS) Get(key string) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.objects[key]
+	if !ok {
+		return nil, ErrObjectNotFound(key)
+	}
+	return append([]byte(nil), entry.value...), nil
+}
+
+func (s *MemoryObjectStoreWithCAS) List(prefix string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := make([]string, 0)
+	for k := range s.objects {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func (s *MemoryObjectStoreWithCAS) GetWithETag(key string) ([]byte, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.objects[key]
+	if !ok {
+		return nil, "", ErrObjectNotFound(key)
+	}
+	return append([]byte(nil), entry.value...), entry.etag, nil
+}
+
+func (s *MemoryObjectStoreWithCAS) PutIfMatch(key string, value []byte, expectedETag string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, exists := s.objects[key]
+	currentETag := ""
+	if exists {
+		currentETag = entry.etag
+	}
+
+	if currentETag != expectedETag {
+		return "", fmt.Errorf("%w: key %s expected %q got %q", ErrCASConflict, key, expectedETag, currentETag)
+	}
+
+	newETag := ContentETag(value)
+	s.objects[key] = casEntry{value: append([]byte(nil), value...), etag: newETag}
+	return newETag, nil
+}

--- a/internal/sync/reader.go
+++ b/internal/sync/reader.go
@@ -1,0 +1,101 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ndelorme/safe/internal/domain"
+	"github.com/ndelorme/safe/internal/storage"
+)
+
+// SyncReader loads incremental state from a shared object store and produces a
+// local Projection. It enforces the monotonicity and (eventually, via W12)
+// signature rules from I7 before applying any events.
+type SyncReader struct {
+	store      storage.ObjectStoreWithCAS
+	verifyHead VerifyHeadFunc
+}
+
+// NewSyncReader returns a SyncReader backed by store. If verifyHead is nil
+// MonotonicVerifyHead is used.
+func NewSyncReader(store storage.ObjectStoreWithCAS, verifyHead VerifyHeadFunc) *SyncReader {
+	if verifyHead == nil {
+		verifyHead = MonotonicVerifyHead
+	}
+	return &SyncReader{store: store, verifyHead: verifyHead}
+}
+
+// IncrementalSync fetches all events for (accountID, collectionID) after since
+// (exclusive), verifies the current head, loads the new events, and replays
+// them. It returns an error if the head fails monotonicity/signature checks,
+// if event continuity is broken, or if replay invariants are violated.
+//
+// A caller that has no local state passes since=0 to load the full history.
+// The returned Projection reflects state up to the current committed head.
+func (r *SyncReader) IncrementalSync(accountID, collectionID string, since int) (Projection, error) {
+	if accountID == "" {
+		return Projection{}, fmt.Errorf("incremental sync: accountID is required")
+	}
+	if collectionID == "" {
+		return Projection{}, fmt.Errorf("incremental sync: collectionID is required")
+	}
+
+	// Fetch and verify the current head.
+	currentHead, _, err := loadHeadWithETag(r.store, accountID, collectionID)
+	if err != nil {
+		if storage.IsObjectNotFound(err) {
+			// No head yet — collection is empty.
+			return Projection{AccountID: accountID, CollectionID: collectionID, Items: make(map[string]domain.VaultItemRecord)}, nil
+		}
+		return Projection{}, fmt.Errorf("incremental sync: read head: %w", err)
+	}
+
+	// Build a synthetic "trusted" head representing the caller's last known
+	// position so we can check the fetched head is a valid advancement.
+	trustedHead := domain.CollectionHeadRecord{
+		SchemaVersion: 1,
+		AccountID:     accountID,
+		CollectionID:  collectionID,
+		LatestSeq:     since,
+	}
+	if err := r.verifyHead(trustedHead, currentHead); err != nil {
+		return Projection{}, fmt.Errorf("incremental sync: head verification: %w", err)
+	}
+
+	if currentHead.LatestSeq == since {
+		// Already up to date.
+		return Projection{AccountID: accountID, CollectionID: collectionID, Items: make(map[string]domain.VaultItemRecord), LatestSeq: since}, nil
+	}
+
+	// Load all event keys under the collection prefix.
+	// Replay always starts from seq=1 (no snapshot support in W15); all events
+	// are loaded and replayed from scratch. The since parameter is only used for
+	// the "already up to date" fast-path above.
+	eventPrefix := storage.EventPrefix(accountID, collectionID)
+	keys, err := r.store.List(eventPrefix)
+	if err != nil {
+		return Projection{}, fmt.Errorf("incremental sync: list events: %w", err)
+	}
+
+	events := make([]domain.VaultEventRecord, 0, len(keys))
+	for _, key := range keys {
+		data, err := r.store.Get(key)
+		if err != nil {
+			return Projection{}, fmt.Errorf("incremental sync: load event %s: %w", key, err)
+		}
+		var ev domain.VaultEventRecord
+		if err := json.Unmarshal(data, &ev); err != nil {
+			return Projection{}, fmt.Errorf("incremental sync: unmarshal event %s: %w", key, err)
+		}
+		events = append(events, ev)
+	}
+
+	// ReplayCollectionAgainstHead verifies sequence continuity, account/collection
+	// binding, and that the final cursor matches the committed head.
+	projection, err := ReplayCollectionAgainstHead(events, currentHead)
+	if err != nil {
+		return Projection{}, fmt.Errorf("incremental sync: replay: %w", err)
+	}
+
+	return projection, nil
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,0 +1,279 @@
+package sync
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ndelorme/safe/internal/domain"
+	"github.com/ndelorme/safe/internal/storage"
+)
+
+// --- helpers ---
+
+const (
+	testAccountID    = "acct-sync-test-001"
+	testCollectionID = "coll-sync-test-001"
+	testDeviceID     = "device-a"
+)
+
+func makeEvent(seq int, itemID string, action domain.VaultEventAction) domain.VaultEventRecord {
+	ev := domain.VaultEventRecord{
+		SchemaVersion: 1,
+		EventID:       fmt.Sprintf("evt-%s-v%d", itemID, seq),
+		AccountID:     testAccountID,
+		DeviceID:      testDeviceID,
+		CollectionID:  testCollectionID,
+		Sequence:      seq,
+		OccurredAt:    time.Now().UTC().Format(time.RFC3339),
+		Action:        action,
+	}
+	if action == domain.VaultEventActionPutItem {
+		ev.ItemRecord = domain.VaultItemRecord{
+			SchemaVersion: 1,
+			Item: domain.VaultItem{
+				ID:          itemID,
+				Kind:        domain.VaultItemKindNote,
+				Title:       "Test " + itemID,
+				Tags:        []string{},
+				BodyPreview: "preview",
+			},
+		}
+	} else {
+		ev.ItemID = itemID
+	}
+	return ev
+}
+
+func makeMutation(seq int, itemID string, action domain.VaultEventAction) SyncMutation {
+	ev := makeEvent(seq, itemID, action)
+	m := SyncMutation{
+		AccountID:    testAccountID,
+		CollectionID: testCollectionID,
+		EventRecord:  ev,
+	}
+	if action == domain.VaultEventActionPutItem {
+		ir := ev.ItemRecord
+		m.ItemRecord = &ir
+	}
+	return m
+}
+
+func newStore() *storage.MemoryObjectStoreWithCAS {
+	return storage.NewMemoryObjectStoreWithCAS()
+}
+
+// --- tests ---
+
+// TestSyncWriterSingleCommit verifies a single mutation is readable after commit.
+func TestSyncWriterSingleCommit(t *testing.T) {
+	store := newStore()
+	writer := NewSyncWriter(store, nil)
+	reader := NewSyncReader(store, nil)
+
+	if err := writer.CommitSyncMutation(makeMutation(1, "item-a", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	proj, err := reader.IncrementalSync(testAccountID, testCollectionID, 0)
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if _, ok := proj.Items["item-a"]; !ok {
+		t.Fatal("expected item-a in projection")
+	}
+	if proj.LatestSeq != 1 {
+		t.Fatalf("expected LatestSeq=1, got %d", proj.LatestSeq)
+	}
+}
+
+// TestTwoRuntimesConverge verifies that two independent SyncWriters sharing
+// one object store produce an identical projection when both sync.
+func TestTwoRuntimesConverge(t *testing.T) {
+	store := newStore()
+	writerA := NewSyncWriter(store, nil)
+	writerB := NewSyncWriter(store, nil)
+	reader := NewSyncReader(store, nil)
+
+	// Runtime A writes seq=1 and seq=2.
+	if err := writerA.CommitSyncMutation(makeMutation(1, "item-a", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("A commit seq=1: %v", err)
+	}
+	if err := writerA.CommitSyncMutation(makeMutation(2, "item-b", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("A commit seq=2: %v", err)
+	}
+
+	// Runtime B syncs to confirm it sees A's writes.
+	projB, err := reader.IncrementalSync(testAccountID, testCollectionID, 0)
+	if err != nil {
+		t.Fatalf("B sync: %v", err)
+	}
+	if projB.LatestSeq != 2 {
+		t.Fatalf("B expected LatestSeq=2, got %d", projB.LatestSeq)
+	}
+
+	// Runtime B appends seq=3.
+	if err := writerB.CommitSyncMutation(makeMutation(3, "item-c", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("B commit seq=3: %v", err)
+	}
+
+	// Final sync sees all three events converged.
+	finalProj, err := reader.IncrementalSync(testAccountID, testCollectionID, 0)
+	if err != nil {
+		t.Fatalf("final sync: %v", err)
+	}
+	if finalProj.LatestSeq != 3 {
+		t.Fatalf("expected LatestSeq=3, got %d", finalProj.LatestSeq)
+	}
+	for _, itemID := range []string{"item-a", "item-b", "item-c"} {
+		if _, ok := finalProj.Items[itemID]; !ok {
+			t.Errorf("expected %s in final projection", itemID)
+		}
+	}
+}
+
+// TestInterruptSafetyImmutablesWithoutHead verifies that immutable objects
+// uploaded without a head advancement are ignored during replay. The head is
+// the commit point; unreachable objects must not affect the projection.
+func TestInterruptSafetyImmutablesWithoutHead(t *testing.T) {
+	store := newStore()
+	reader := NewSyncReader(store, nil)
+
+	// Manually upload an event without advancing the head.
+	// This simulates a crash after step 2 (immutable upload) but before CAS.
+	ev := makeEvent(1, "orphan-item", domain.VaultEventActionPutItem)
+	evBytes, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal orphan event: %v", err)
+	}
+	if err := store.Put(storage.EventObjectKey(testAccountID, testCollectionID, ev.EventID), evBytes); err != nil {
+		t.Fatalf("upload orphan event: %v", err)
+	}
+
+	// No head was written — the projection must be empty.
+	proj, err := reader.IncrementalSync(testAccountID, testCollectionID, 0)
+	if err != nil {
+		t.Fatalf("sync after orphan upload: %v", err)
+	}
+	if len(proj.Items) != 0 {
+		t.Fatalf("expected empty projection with no head, got %d items", len(proj.Items))
+	}
+}
+
+// TestStaleHeadRejected verifies that IncrementalSync rejects a candidate head
+// that is behind the caller's claimed cursor (since value).
+func TestStaleHeadRejected(t *testing.T) {
+	store := newStore()
+	writer := NewSyncWriter(store, nil)
+
+	if err := writer.CommitSyncMutation(makeMutation(1, "item-a", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("commit seq=1: %v", err)
+	}
+	if err := writer.CommitSyncMutation(makeMutation(2, "item-b", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("commit seq=2: %v", err)
+	}
+
+	// Request sync with since=3 (ahead of the committed head at seq=2).
+	// The head (seq=2) is stale relative to the caller's cursor (3).
+	_, err := NewSyncReader(store, nil).IncrementalSync(testAccountID, testCollectionID, 3)
+	if err == nil {
+		t.Fatal("expected error when head is behind caller cursor, got nil")
+	}
+}
+
+// TestIdempotentCommit verifies that committing the same event twice succeeds
+// on the second attempt without error or duplication.
+func TestIdempotentCommit(t *testing.T) {
+	store := newStore()
+	writer := NewSyncWriter(store, nil)
+	m := makeMutation(1, "item-a", domain.VaultEventActionPutItem)
+
+	if err := writer.CommitSyncMutation(m); err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+	if err := writer.CommitSyncMutation(m); err != nil {
+		t.Fatalf("second commit (idempotent): %v", err)
+	}
+
+	proj, err := NewSyncReader(store, nil).IncrementalSync(testAccountID, testCollectionID, 0)
+	if err != nil {
+		t.Fatalf("sync after idempotent commits: %v", err)
+	}
+	if proj.LatestSeq != 1 {
+		t.Fatalf("expected LatestSeq=1 after idempotent commits, got %d", proj.LatestSeq)
+	}
+}
+
+// TestCASConflictIsDetected verifies ErrCASConflict is returned when a stale
+// ETag is presented to PutIfMatch.
+func TestCASConflictIsDetected(t *testing.T) {
+	store := newStore()
+
+	// Write seq=1 so we have an initial ETag.
+	writer := NewSyncWriter(store, nil)
+	if err := writer.CommitSyncMutation(makeMutation(1, "item-a", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("setup commit: %v", err)
+	}
+
+	headKey := storage.CollectionHeadKey(testAccountID, testCollectionID)
+	_, etag, err := store.GetWithETag(headKey)
+	if err != nil {
+		t.Fatalf("get head ETag: %v", err)
+	}
+
+	// A concurrent writer advances the head.
+	if err := NewSyncWriter(store, nil).CommitSyncMutation(makeMutation(2, "item-b", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("concurrent commit: %v", err)
+	}
+
+	// The stale ETag must now cause a CAS conflict.
+	_, casErr := store.PutIfMatch(headKey, []byte(`{}`), etag)
+	if !errors.Is(casErr, storage.ErrCASConflict) {
+		t.Fatalf("expected ErrCASConflict, got %v", casErr)
+	}
+}
+
+// TestEmptyCollectionSync verifies sync on a collection with no committed
+// events returns an empty projection without error.
+func TestEmptyCollectionSync(t *testing.T) {
+	store := newStore()
+	reader := NewSyncReader(store, nil)
+
+	proj, err := reader.IncrementalSync(testAccountID, testCollectionID, 0)
+	if err != nil {
+		t.Fatalf("sync on empty collection: %v", err)
+	}
+	if proj.LatestSeq != 0 {
+		t.Fatalf("expected LatestSeq=0 for empty collection, got %d", proj.LatestSeq)
+	}
+	if len(proj.Items) != 0 {
+		t.Fatalf("expected 0 items for empty collection, got %d", len(proj.Items))
+	}
+}
+
+// TestDeleteEventConverges verifies that a delete event removes the item from
+// the projection in both runtimes.
+func TestDeleteEventConverges(t *testing.T) {
+	store := newStore()
+	writer := NewSyncWriter(store, nil)
+
+	if err := writer.CommitSyncMutation(makeMutation(1, "item-a", domain.VaultEventActionPutItem)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := writer.CommitSyncMutation(makeMutation(2, "item-a", domain.VaultEventActionDeleteItem)); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	proj, err := NewSyncReader(store, nil).IncrementalSync(testAccountID, testCollectionID, 0)
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if _, ok := proj.Items["item-a"]; ok {
+		t.Fatal("deleted item-a should not appear in projection")
+	}
+	if proj.LatestSeq != 2 {
+		t.Fatalf("expected LatestSeq=2, got %d", proj.LatestSeq)
+	}
+}

--- a/internal/sync/verify.go
+++ b/internal/sync/verify.go
@@ -1,0 +1,28 @@
+package sync
+
+import "github.com/ndelorme/safe/internal/domain"
+
+// VerifyHeadFunc authenticates and freshness-checks a candidate head record
+// against the most recently trusted head. It must return nil only when the
+// candidate is strictly at least as advanced as trusted and its integrity holds.
+//
+// W12 will replace the default stub (MonotonicVerifyHead) with a function that
+// also verifies the Ed25519 signature carried by the event the head references.
+// Callers should inject VerifyHeadFunc via NewSyncWriter / NewSyncReader rather
+// than calling MonotonicVerifyHead directly, so the W12 upgrade is a one-line
+// swap at the call site.
+type VerifyHeadFunc func(trusted, candidate domain.CollectionHeadRecord) error
+
+// MonotonicVerifyHead checks that candidate is a valid monotonic advancement of
+// trusted: same account and collection, non-decreasing sequence, and no
+// divergence at the same sequence number.
+//
+// This is the W15 stub. W12 will add Ed25519 event-signature verification on
+// top of these monotonicity rules without changing the function signature.
+func MonotonicVerifyHead(trusted, candidate domain.CollectionHeadRecord) error {
+	// Genesis: no trusted state to compare against.
+	if trusted.LatestSeq == 0 && trusted.LatestEventID == "" {
+		return nil
+	}
+	return EnsureMonotonicHead(trusted, candidate)
+}

--- a/internal/sync/writer.go
+++ b/internal/sync/writer.go
@@ -1,0 +1,163 @@
+package sync
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ndelorme/safe/internal/domain"
+	"github.com/ndelorme/safe/internal/storage"
+)
+
+// maxCASRetries is the maximum number of times CommitSyncMutation will retry
+// after a CAS conflict before giving up.
+const maxCASRetries = 10
+
+// SyncMutation describes the records to commit to the shared object store in
+// one logical sync operation. Unlike storage.VaultMutation it carries no
+// secret material; secrets stay in the local encrypted store only.
+type SyncMutation struct {
+	AccountID    string
+	CollectionID string
+	EventRecord  domain.VaultEventRecord
+	ItemRecord   *domain.VaultItemRecord // nil for delete events
+}
+
+// SyncWriter commits vault mutations to a shared object store using the
+// write protocol from SYSTEM_DESIGN §11:
+//
+//  1. Read current head with ETag.
+//  2. Upload immutable objects (item, event) unconditionally.
+//  3. CAS-advance the head pointer.
+//  4. On conflict, re-read head, check idempotency, and rebuild if needed.
+//
+// The VerifyHead hook will be replaced by W12's signed-metadata verifier once
+// the event signature envelope is frozen. Until then it validates monotonicity.
+type SyncWriter struct {
+	store      storage.ObjectStoreWithCAS
+	verifyHead VerifyHeadFunc
+}
+
+// NewSyncWriter returns a SyncWriter backed by store. If verifyHead is nil the
+// default monotonicity-only check is used (see MonotonicVerifyHead).
+func NewSyncWriter(store storage.ObjectStoreWithCAS, verifyHead VerifyHeadFunc) *SyncWriter {
+	if verifyHead == nil {
+		verifyHead = MonotonicVerifyHead
+	}
+	return &SyncWriter{store: store, verifyHead: verifyHead}
+}
+
+// CommitSyncMutation writes m to the shared object store, retrying up to
+// maxCASRetries times on CAS conflict. It returns an error if the operation
+// cannot succeed after the retry budget is exhausted.
+//
+// Immutable objects (item record, event record) are uploaded before the head
+// is advanced. A crash after the uploads but before the CAS leaves unreachable
+// immutable objects in the store, which is safe — they are ignored during
+// normal replay because no committed head references them.
+func (w *SyncWriter) CommitSyncMutation(m SyncMutation) error {
+	if m.AccountID == "" {
+		return fmt.Errorf("sync commit: accountID is required")
+	}
+	if m.CollectionID == "" {
+		return fmt.Errorf("sync commit: collectionID is required")
+	}
+	if err := m.EventRecord.Validate(); err != nil {
+		return fmt.Errorf("sync commit: invalid event record: %w", err)
+	}
+
+	for attempt := 0; attempt < maxCASRetries; attempt++ {
+		// Step 1: read current head and ETag.
+		currentHead, currentETag, err := loadHeadWithETag(w.store, m.AccountID, m.CollectionID)
+		if err != nil && !storage.IsObjectNotFound(err) {
+			return fmt.Errorf("sync commit: read head: %w", err)
+		}
+		// An absent head means this is the genesis write; currentETag is "".
+
+		// Verify the current head is not stale compared to any local trusted state.
+		// (No-op for genesis; monotonic check on subsequent writes.)
+		if currentETag != "" {
+			if verifyErr := w.verifyHead(currentHead, currentHead); verifyErr != nil {
+				return fmt.Errorf("sync commit: head verification: %w", verifyErr)
+			}
+		}
+
+		// Idempotency check: if our event is already referenced by the current head,
+		// the mutation committed on a previous attempt.
+		if currentETag != "" && currentHead.LatestEventID == m.EventRecord.EventID {
+			return nil
+		}
+
+		// The new event must strictly advance the sequence.
+		expectedSeq := 1
+		if currentETag != "" {
+			expectedSeq = currentHead.LatestSeq + 1
+		}
+		if m.EventRecord.Sequence != expectedSeq {
+			return fmt.Errorf("sync commit: event sequence %d does not match expected %d (head seq %d)",
+				m.EventRecord.Sequence, expectedSeq, currentHead.LatestSeq)
+		}
+
+		// Step 2: upload immutable objects (safe to redo on retry).
+		if m.ItemRecord != nil {
+			payload, err := m.ItemRecord.CanonicalJSON()
+			if err != nil {
+				return fmt.Errorf("sync commit: marshal item record: %w", err)
+			}
+			key := storage.ItemObjectKey(m.AccountID, m.CollectionID, m.ItemRecord.Item.ID)
+			if err := w.store.Put(key, payload); err != nil {
+				return fmt.Errorf("sync commit: upload item record: %w", err)
+			}
+		}
+
+		eventPayload, err := json.Marshal(m.EventRecord)
+		if err != nil {
+			return fmt.Errorf("sync commit: marshal event record: %w", err)
+		}
+		eventKey := storage.EventObjectKey(m.AccountID, m.CollectionID, m.EventRecord.EventID)
+		if err := w.store.Put(eventKey, eventPayload); err != nil {
+			return fmt.Errorf("sync commit: upload event record: %w", err)
+		}
+
+		// Step 3: build and CAS-advance the head pointer.
+		newHead := domain.CollectionHeadRecord{
+			SchemaVersion: 1,
+			AccountID:     m.AccountID,
+			CollectionID:  m.CollectionID,
+			LatestEventID: m.EventRecord.EventID,
+			LatestSeq:     m.EventRecord.Sequence,
+		}
+		headPayload, err := newHead.CanonicalJSON()
+		if err != nil {
+			return fmt.Errorf("sync commit: marshal new head: %w", err)
+		}
+		headKey := storage.CollectionHeadKey(m.AccountID, m.CollectionID)
+		_, casErr := w.store.PutIfMatch(headKey, headPayload, currentETag)
+		if casErr == nil {
+			return nil // committed
+		}
+
+		// Step 4: CAS conflict — another writer advanced the head concurrently.
+		if !errors.Is(casErr, storage.ErrCASConflict) {
+			return fmt.Errorf("sync commit: advance head: %w", casErr)
+		}
+		// Loop: re-read head and retry.
+	}
+
+	return fmt.Errorf("sync commit: exceeded %d CAS retries for %s/%s", maxCASRetries, m.AccountID, m.CollectionID)
+}
+
+// loadHeadWithETag reads the collection head from the store and returns its ETag.
+// Returns a zero-value head and "" ETag when the head does not yet exist.
+func loadHeadWithETag(store storage.ObjectStoreWithCAS, accountID, collectionID string) (domain.CollectionHeadRecord, string, error) {
+	key := storage.CollectionHeadKey(accountID, collectionID)
+	data, etag, err := store.GetWithETag(key)
+	if err != nil {
+		return domain.CollectionHeadRecord{}, "", err
+	}
+	var head domain.CollectionHeadRecord
+	if err := json.Unmarshal(data, &head); err != nil {
+		return domain.CollectionHeadRecord{}, "", fmt.Errorf("unmarshal head: %w", err)
+	}
+	return head, etag, nil
+}


### PR DESCRIPTION
## Task

W15: Implement account-path object-store sync and commit protocol (refs #33)

## Owner

Engineer2 (Claude)

## Write scope

- `internal/storage/cas.go` — ObjectStoreWithCAS interface + MemoryObjectStoreWithCAS
- `internal/sync/writer.go` — SyncWriter with CAS-based head advancement
- `internal/sync/reader.go` — SyncReader incremental sync
- `internal/sync/verify.go` — VerifyHeadFunc interface + MonotonicVerifyHead (W12 stub)
- `internal/sync/sync_test.go` — 8 convergence and safety tests
- `docs/project/WORKBOARD.md`, `docs/project/HANDOFFS.md` — status updates

## Dependency status

- W11 (#31): complete
- W12 (#36): Todo (Engineer1) — W15 ships with injectable VerifyHeadFunc stub; W12 drops in the real verifier
- W13 (#35): complete (cross-boundary, merged in #39)
- W8 (#19): complete

## Acceptance checks run

- `go test ./...` — all pass
- Two runtimes converge through shared MemoryObjectStoreWithCAS
- Interrupted commit (immutables uploaded, no head advancement) leaves empty projection
- Stale head is rejected (caller cursor ahead of store head)
- Idempotent commit on same EventID succeeds without duplication
- CAS conflict correctly returns ErrCASConflict
- Delete event removes item from final projection

## W12 integration design

W15 ships `VerifyHeadFunc` as an injectable interface. The default stub (`MonotonicVerifyHead`) validates freshness only. When W12 defines the Ed25519 event signature envelope:

```go
writer := NewSyncWriter(store, w12.VerifySignedHead)
reader := NewSyncReader(store, w12.VerifySignedHead)
```

No W15 files need to change for W12 integration.

## Risks

- `IncrementalSync` always replays from seq=1 (no snapshot support in W15); this is correct but will become expensive for long event logs. Snapshots are deferred per SYSTEM_DESIGN.
- `VerifyHeadFunc` stub does not verify Ed25519 signatures — intentional, pending W12. Any merge of W15 before W12 should be understood as a "verification hook wired but not cryptographically enforced" state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)