### PR TITLE
feat(api): add account-scoped access capability issuance

### DIFF
--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"os"
+	"time"
+
+	"github.com/ndelorme/safe/internal/auth"
 )
 
 type statusResponse struct {
@@ -27,23 +31,50 @@ type storageConfigResponse struct {
 	DeviceID  string `json:"deviceId"`
 }
 
+type accountAccessRequest struct {
+	AccountID      string   `json:"accountId"`
+	DeviceID       string   `json:"deviceId"`
+	AllowedActions []string `json:"allowedActions"`
+}
+
+type accountAccessResponse struct {
+	Bucket     string                `json:"bucket"`
+	Endpoint   string                `json:"endpoint"`
+	Region     string                `json:"region"`
+	KeyID      string                `json:"keyId"`
+	Token      string                `json:"token"`
+	Capability auth.AccessCapability `json:"capability"`
+}
+
 type serverConfig struct {
-	env       string
-	accountID string
-	deviceID  string
-	bucket    string
-	endpoint  string
-	region    string
+	env        string
+	accountID  string
+	deviceID   string
+	bucket     string
+	endpoint   string
+	region     string
+	accessTTL  time.Duration
+	capability *auth.CapabilitySigner
 }
 
 func main() {
+	capability, err := auth.NewCapabilitySigner(
+		getenvDefault("SAFE_CONTROL_PLANE_KEY_ID", "dev-hmac-v1"),
+		[]byte(getenvDefault("SAFE_CONTROL_PLANE_HMAC_SECRET", "0123456789abcdef0123456789abcdef")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	cfg := serverConfig{
-		env:       getenvDefault("SAFE_ENV", "development"),
-		accountID: getenvDefault("SAFE_DEV_ACCOUNT_ID", "acct-dev-001"),
-		deviceID:  getenvDefault("SAFE_DEV_DEVICE_ID", "dev-web-001"),
-		bucket:    getenvDefault("SAFE_S3_BUCKET", "safe-dev"),
-		endpoint:  getenvDefault("SAFE_S3_ENDPOINT", "http://localstack:4566"),
-		region:    getenvDefault("AWS_REGION", "us-east-1"),
+		env:        getenvDefault("SAFE_ENV", "development"),
+		accountID:  getenvDefault("SAFE_DEV_ACCOUNT_ID", "acct-dev-001"),
+		deviceID:   getenvDefault("SAFE_DEV_DEVICE_ID", "dev-web-001"),
+		bucket:     getenvDefault("SAFE_S3_BUCKET", "safe-dev"),
+		endpoint:   getenvDefault("SAFE_S3_ENDPOINT", "http://localstack:4566"),
+		region:     getenvDefault("AWS_REGION", "us-east-1"),
+		accessTTL:  5 * time.Minute,
+		capability: capability,
 	}
 
 	addr := ":8080"
@@ -95,6 +126,52 @@ func newServer(cfg serverConfig) http.Handler {
 			DeviceID:  cfg.deviceID,
 		})
 	})
+	mux.HandleFunc("/v1/access/account", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var request accountAccessRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		if request.AccountID != cfg.accountID || request.DeviceID != cfg.deviceID {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		if err := auth.ValidateActiveDevice(request.AccountID, request.DeviceID, cfg.deviceLookup); err != nil {
+			writeAccessError(w, err)
+			return
+		}
+
+		actions := request.AllowedActions
+		if len(actions) == 0 {
+			actions = []string{auth.ActionGet, auth.ActionPut}
+		}
+
+		signed, err := cfg.capability.IssueAccountCapability(auth.AccountAccessRequest{
+			AccountID:      request.AccountID,
+			DeviceID:       request.DeviceID,
+			Bucket:         cfg.bucket,
+			AllowedActions: actions,
+			TTL:            cfg.accessTTL,
+		})
+		if err != nil {
+			writeAccessError(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, accountAccessResponse{
+			Bucket:     cfg.bucket,
+			Endpoint:   cfg.endpoint,
+			Region:     cfg.region,
+			KeyID:      signed.KeyID,
+			Token:      signed.Token,
+			Capability: signed.Capability,
+		})
+	})
 
 	return mux
 }
@@ -115,4 +192,25 @@ func getenvDefault(key, fallback string) string {
 	}
 
 	return value
+}
+
+func (cfg serverConfig) deviceLookup(accountID, deviceID string) (bool, error) {
+	return accountID == cfg.accountID && deviceID == cfg.deviceID, nil
+}
+
+func writeAccessError(w http.ResponseWriter, err error) {
+	switch {
+	case err == nil:
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	case errors.Is(err, auth.ErrForbiddenAccess("device")):
+		http.Error(w, "forbidden", http.StatusForbidden)
+	case errors.Is(err, auth.ErrInvalidCapability("accountId")),
+		errors.Is(err, auth.ErrInvalidCapability("deviceId")),
+		errors.Is(err, auth.ErrInvalidCapability("bucket")),
+		errors.Is(err, auth.ErrInvalidCapability("allowedActions")),
+		errors.Is(err, auth.ErrInvalidCapability("ttl")):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	default:
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}
 }

--- a/cmd/control-plane/main_test.go
+++ b/cmd/control-plane/main_test.go
@@ -6,17 +6,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/ndelorme/safe/internal/auth"
 )
 
 func TestDevSessionEndpoint(t *testing.T) {
-	server := newServer(serverConfig{
-		env:       "test",
-		accountID: "acct-test-001",
-		deviceID:  "dev-test-001",
-		bucket:    "safe-test",
-		endpoint:  "http://localstack:4566",
-		region:    "us-east-1",
-	})
+	server := newServer(newTestServerConfig(t))
 
 	request := httptest.NewRequest(http.MethodPost, "/v1/dev/session", strings.NewReader(`{}`))
 	response := httptest.NewRecorder()
@@ -38,14 +34,7 @@ func TestDevSessionEndpoint(t *testing.T) {
 }
 
 func TestStorageConfigEndpoint(t *testing.T) {
-	server := newServer(serverConfig{
-		env:       "test",
-		accountID: "acct-test-001",
-		deviceID:  "dev-test-001",
-		bucket:    "safe-test",
-		endpoint:  "http://localstack:4566",
-		region:    "us-east-1",
-	})
+	server := newServer(newTestServerConfig(t))
 
 	request := httptest.NewRequest(http.MethodGet, "/v1/dev/storage-config", nil)
 	response := httptest.NewRecorder()
@@ -67,7 +56,7 @@ func TestStorageConfigEndpoint(t *testing.T) {
 }
 
 func TestDevSessionMethodGuard(t *testing.T) {
-	server := newServer(serverConfig{})
+	server := newServer(newTestServerConfig(t))
 	request := httptest.NewRequest(http.MethodGet, "/v1/dev/session", nil)
 	response := httptest.NewRecorder()
 
@@ -75,5 +64,83 @@ func TestDevSessionMethodGuard(t *testing.T) {
 
 	if response.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, response.Code)
+	}
+}
+
+func TestAccountAccessEndpoint(t *testing.T) {
+	server := newServer(newTestServerConfig(t))
+	request := httptest.NewRequest(http.MethodPost, "/v1/access/account", strings.NewReader(`{"accountId":"acct-test-001","deviceId":"dev-test-001"}`))
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	var payload accountAccessResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Capability.Prefix != "accounts/acct-test-001/" {
+		t.Fatalf("unexpected prefix: %s", payload.Capability.Prefix)
+	}
+	if len(payload.Capability.AllowedActions) != 2 || payload.Capability.AllowedActions[0] != auth.ActionGet || payload.Capability.AllowedActions[1] != auth.ActionPut {
+		t.Fatalf("unexpected actions: %#v", payload.Capability.AllowedActions)
+	}
+}
+
+func TestAccountAccessEndpointRejectsMismatchedIdentity(t *testing.T) {
+	server := newServer(newTestServerConfig(t))
+	request := httptest.NewRequest(http.MethodPost, "/v1/access/account", strings.NewReader(`{"accountId":"acct-other-001","deviceId":"dev-test-001"}`))
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, response.Code)
+	}
+}
+
+func TestAccountAccessEndpointAllowsExplicitList(t *testing.T) {
+	server := newServer(newTestServerConfig(t))
+	request := httptest.NewRequest(http.MethodPost, "/v1/access/account", strings.NewReader(`{"accountId":"acct-test-001","deviceId":"dev-test-001","allowedActions":["list","get"]}`))
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	var payload accountAccessResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Capability.AllowedActions) != 2 || payload.Capability.AllowedActions[0] != auth.ActionGet || payload.Capability.AllowedActions[1] != auth.ActionList {
+		t.Fatalf("unexpected actions: %#v", payload.Capability.AllowedActions)
+	}
+}
+
+func newTestServerConfig(t *testing.T) serverConfig {
+	t.Helper()
+
+	capability, err := auth.NewCapabilitySigner("test-key", []byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	capability.SetNowForTest(func() time.Time {
+		return time.Date(2026, 4, 6, 8, 0, 0, 0, time.UTC)
+	})
+
+	return serverConfig{
+		env:        "test",
+		accountID:  "acct-test-001",
+		deviceID:   "dev-test-001",
+		bucket:     "safe-test",
+		endpoint:   "http://localstack:4566",
+		region:     "us-east-1",
+		accessTTL:  5 * time.Minute,
+		capability: capability,
 	}
 }

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -39,6 +39,35 @@ Current planning issues:
 
 ## Entries
 
+### 2026-04-06 - Engineer1 progress note (W16)
+
+Task:
+
+- `W16 - Implement minimal control-plane access mediation for single-account sync`
+
+Status:
+
+- in progress; refs #32
+
+Files touched:
+
+- `docs/project/INTERFACES.md` (new I9 account-scoped access capability contract)
+- `docs/project/WORKBOARD.md` (W16 status and output update)
+- `internal/auth/access.go` (new signed access-capability issuance and verification helpers)
+- `internal/auth/access_test.go` (new method escalation, prefix overreach, list-by-default, expiry, and device-state tests)
+- `cmd/control-plane/main.go` (new `/v1/access/account` issuance endpoint)
+- `cmd/control-plane/main_test.go` (control-plane issuance endpoint coverage)
+
+Outcome:
+
+- W16 now has a frozen minimal capability contract for account-scoped object access at `accounts/<accountID>/`
+- the control plane issues short-lived signed capabilities bound to `accountId`, `deviceId`, `bucket`, allowed actions, and expiry
+- default issuance is `get` plus `put`; `list` remains explicit instead of implied
+
+Next action:
+
+- update GitHub issue `#32` and the project board to match repo state, then open a PR so W17 can consume the frozen W16 access path
+
 ### 2026-04-06 - Engineer2 completion note (W15)
 
 Task:

--- a/docs/project/INTERFACES.md
+++ b/docs/project/INTERFACES.md
@@ -510,6 +510,66 @@ When no trusted device is available:
 - device revocation flows
 - mutable metadata signing (separate slice)
 
+## I9 - Account-Scoped Object Access Capability Contract
+
+Status:
+
+- accepted
+
+Owner:
+
+- Engineer1 (`refs #32`)
+
+Frozen for W16 (`refs #32`):
+
+Goals:
+
+- define the minimal control-plane-issued access contract needed for single-account sync
+- keep object-store access short-lived, path-scoped, and operation-bound
+- leave sharing and broader collection-scoped authorization for later milestones
+
+Capability payload:
+
+```json
+{
+  "version": 1,
+  "accountId": "<accountID>",
+  "deviceId": "<deviceID>",
+  "bucket": "<bucket name>",
+  "prefix": "accounts/<accountID>/",
+  "allowedActions": ["get", "put"],
+  "issuedAt": "<RFC 3339 timestamp>",
+  "expiresAt": "<RFC 3339 timestamp>"
+}
+```
+
+Fields:
+
+- `version`: integer, must be `1`
+- `accountId`: the authenticated account receiving access
+- `deviceId`: the authenticated device receiving access; must identify an active device record for the same account
+- `bucket`: the object-store bucket the capability is valid against
+- `prefix`: the only authorized object prefix for this capability; for W16 it is always `accounts/<accountID>/`
+- `allowedActions`: non-empty set drawn from `"get"`, `"put"`, and `"list"`; `"list"` is optional and must never be implied by `"get"` or `"put"`
+- `issuedAt`: RFC 3339 issuance time recorded by the control plane
+- `expiresAt`: RFC 3339 expiry time recorded by the control plane
+
+Capability rules:
+
+- capabilities are authenticated by the control plane as signed opaque tokens whose payload matches the fields above
+- W16 capabilities are account-scoped only; they must not grant collection-specific sharing access or any prefix outside `accounts/<accountID>/`
+- the control plane must bind the capability to both `accountId` and `deviceId`; cross-account or cross-device reuse is invalid
+- default issuance for single-account sync is `"get"` plus `"put"` only; `"list"` requires explicit request and must remain off by default
+- clients and storage-facing adapters must treat `expiresAt` as a hard limit; expired capabilities are invalid even if the signature is otherwise correct
+- verification must reject method escalation, prefix escape, empty prefixes, bucket mismatch, and non-account-local object paths
+
+Out of scope for W16:
+
+- durable control-plane storage for session state
+- one-time-use capability tracking
+- shared-collection authorization
+- provider-specific IAM policies or pre-signed URL formats
+
 ## I5 - Handoff Protocol
 
 Status:

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -505,7 +505,7 @@ Owner:
 
 Status:
 
-- planned (`refs #32`)
+- in progress (`refs #32`)
 
 Write scope:
 
@@ -516,6 +516,7 @@ Write scope:
 Output:
 
 - narrow account-scoped object-access path for single-user sync
+- freeze I9 for signed account-scoped access capabilities with default `get` and `put` only
 
 Dependencies:
 

--- a/internal/auth/access.go
+++ b/internal/auth/access.go
@@ -1,0 +1,391 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	ActionGet  = "get"
+	ActionPut  = "put"
+	ActionList = "list"
+)
+
+var validActions = []string{ActionGet, ActionPut, ActionList}
+
+type DeviceStatusLookup func(accountID, deviceID string) (bool, error)
+
+type CapabilitySigner struct {
+	keyID     string
+	secretKey []byte
+	now       func() time.Time
+}
+
+type AccountAccessRequest struct {
+	AccountID      string
+	DeviceID       string
+	Bucket         string
+	AllowedActions []string
+	TTL            time.Duration
+}
+
+type AccessCapability struct {
+	Version        int      `json:"version"`
+	AccountID      string   `json:"accountId"`
+	DeviceID       string   `json:"deviceId"`
+	Bucket         string   `json:"bucket"`
+	Prefix         string   `json:"prefix"`
+	AllowedActions []string `json:"allowedActions"`
+	IssuedAt       string   `json:"issuedAt"`
+	ExpiresAt      string   `json:"expiresAt"`
+}
+
+type SignedCapability struct {
+	KeyID      string `json:"keyId"`
+	Token      string `json:"token"`
+	Capability AccessCapability
+}
+
+type AccessCheck struct {
+	Bucket string
+	Action string
+	Key    string
+	Now    time.Time
+}
+
+func NewCapabilitySigner(keyID string, secretKey []byte) (*CapabilitySigner, error) {
+	if keyID == "" {
+		return nil, ErrInvalidCapability("keyId")
+	}
+	if len(secretKey) < 32 {
+		return nil, ErrInvalidCapability("secretKey")
+	}
+
+	return &CapabilitySigner{
+		keyID:     keyID,
+		secretKey: append([]byte(nil), secretKey...),
+		now:       time.Now,
+	}, nil
+}
+
+func (s *CapabilitySigner) SetNowForTest(now func() time.Time) {
+	if now != nil {
+		s.now = now
+	}
+}
+
+func (s *CapabilitySigner) IssueAccountCapability(request AccountAccessRequest) (SignedCapability, error) {
+	if err := validateAccountAccessRequest(request); err != nil {
+		return SignedCapability{}, err
+	}
+
+	issuedAt := s.now().UTC().Truncate(time.Second)
+	expiresAt := issuedAt.Add(request.TTL)
+	capability := AccessCapability{
+		Version:        1,
+		AccountID:      request.AccountID,
+		DeviceID:       request.DeviceID,
+		Bucket:         request.Bucket,
+		Prefix:         accountPrefix(request.AccountID),
+		AllowedActions: normalizeActions(request.AllowedActions),
+		IssuedAt:       issuedAt.Format(time.RFC3339),
+		ExpiresAt:      expiresAt.Format(time.RFC3339),
+	}
+
+	token, err := s.sign(capability)
+	if err != nil {
+		return SignedCapability{}, err
+	}
+
+	return SignedCapability{
+		KeyID:      s.keyID,
+		Token:      token,
+		Capability: capability,
+	}, nil
+}
+
+func (s *CapabilitySigner) VerifyAccountAccess(token string, check AccessCheck) (AccessCapability, error) {
+	capability, err := s.parseAndVerify(token)
+	if err != nil {
+		return AccessCapability{}, err
+	}
+	if err := capability.Validate(); err != nil {
+		return AccessCapability{}, err
+	}
+	if capability.Bucket != check.Bucket {
+		return AccessCapability{}, ErrForbiddenAccess("bucket")
+	}
+	if !containsAction(capability.AllowedActions, check.Action) {
+		return AccessCapability{}, ErrForbiddenAccess("action")
+	}
+	if !strings.HasPrefix(check.Key, capability.Prefix) {
+		return AccessCapability{}, ErrForbiddenAccess("prefix")
+	}
+	if !isNormalizedObjectKey(check.Key) {
+		return AccessCapability{}, ErrForbiddenAccess("key")
+	}
+
+	now := check.Now
+	if now.IsZero() {
+		now = s.now()
+	}
+	expiresAt, _ := time.Parse(time.RFC3339, capability.ExpiresAt)
+	if !now.UTC().Before(expiresAt) {
+		return AccessCapability{}, ErrExpiredCapability()
+	}
+
+	return capability, nil
+}
+
+func (c AccessCapability) Validate() error {
+	if c.Version != 1 {
+		return ErrInvalidCapability("version")
+	}
+	if !isValidIdentitySegment(c.AccountID) {
+		return ErrInvalidCapability("accountId")
+	}
+	if !isValidIdentitySegment(c.DeviceID) {
+		return ErrInvalidCapability("deviceId")
+	}
+	if c.Bucket == "" {
+		return ErrInvalidCapability("bucket")
+	}
+	if c.Prefix != accountPrefix(c.AccountID) {
+		return ErrInvalidCapability("prefix")
+	}
+	if len(c.AllowedActions) == 0 {
+		return ErrInvalidCapability("allowedActions")
+	}
+	if !isSortedUniqueActions(c.AllowedActions) {
+		return ErrInvalidCapability("allowedActions")
+	}
+	for _, action := range c.AllowedActions {
+		if !containsAction(validActions, action) {
+			return ErrInvalidCapability("allowedActions")
+		}
+	}
+	issuedAt, err := time.Parse(time.RFC3339, c.IssuedAt)
+	if err != nil {
+		return ErrInvalidCapability("issuedAt")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, c.ExpiresAt)
+	if err != nil {
+		return ErrInvalidCapability("expiresAt")
+	}
+	if !issuedAt.Before(expiresAt) {
+		return ErrInvalidCapability("expiresAt")
+	}
+
+	return nil
+}
+
+func ValidateActiveDevice(accountID, deviceID string, lookup DeviceStatusLookup) error {
+	if !isValidIdentitySegment(accountID) {
+		return ErrInvalidCapability("accountId")
+	}
+	if !isValidIdentitySegment(deviceID) {
+		return ErrInvalidCapability("deviceId")
+	}
+	if lookup == nil {
+		return nil
+	}
+
+	active, err := lookup(accountID, deviceID)
+	if err != nil {
+		return err
+	}
+	if !active {
+		return ErrForbiddenAccess("device")
+	}
+
+	return nil
+}
+
+func (s *CapabilitySigner) sign(capability AccessCapability) (string, error) {
+	payload, err := canonicalCapabilityPayload(capability)
+	if err != nil {
+		return "", err
+	}
+
+	mac := hmac.New(sha256.New, s.secretKey)
+	mac.Write(payload)
+	signature := mac.Sum(nil)
+
+	return base64.RawURLEncoding.EncodeToString(payload) + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func (s *CapabilitySigner) parseAndVerify(token string) (AccessCapability, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return AccessCapability{}, ErrInvalidCapability("token")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return AccessCapability{}, ErrInvalidCapability("token")
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return AccessCapability{}, ErrInvalidCapability("token")
+	}
+
+	mac := hmac.New(sha256.New, s.secretKey)
+	mac.Write(payload)
+	if !hmac.Equal(signature, mac.Sum(nil)) {
+		return AccessCapability{}, ErrInvalidCapability("signature")
+	}
+
+	var capability AccessCapability
+	if err := json.Unmarshal(payload, &capability); err != nil {
+		return AccessCapability{}, ErrInvalidCapability("token")
+	}
+
+	return capability, nil
+}
+
+func canonicalCapabilityPayload(capability AccessCapability) ([]byte, error) {
+	if err := capability.Validate(); err != nil {
+		return nil, err
+	}
+
+	type canonical struct {
+		Version        int      `json:"version"`
+		AccountID      string   `json:"accountId"`
+		DeviceID       string   `json:"deviceId"`
+		Bucket         string   `json:"bucket"`
+		Prefix         string   `json:"prefix"`
+		AllowedActions []string `json:"allowedActions"`
+		IssuedAt       string   `json:"issuedAt"`
+		ExpiresAt      string   `json:"expiresAt"`
+	}
+
+	return json.Marshal(canonical{
+		Version:        capability.Version,
+		AccountID:      capability.AccountID,
+		DeviceID:       capability.DeviceID,
+		Bucket:         capability.Bucket,
+		Prefix:         capability.Prefix,
+		AllowedActions: capability.AllowedActions,
+		IssuedAt:       capability.IssuedAt,
+		ExpiresAt:      capability.ExpiresAt,
+	})
+}
+
+func validateAccountAccessRequest(request AccountAccessRequest) error {
+	if !isValidIdentitySegment(request.AccountID) {
+		return ErrInvalidCapability("accountId")
+	}
+	if !isValidIdentitySegment(request.DeviceID) {
+		return ErrInvalidCapability("deviceId")
+	}
+	if request.Bucket == "" {
+		return ErrInvalidCapability("bucket")
+	}
+	if request.TTL <= 0 || request.TTL > 15*time.Minute {
+		return ErrInvalidCapability("ttl")
+	}
+	actions := normalizeActions(request.AllowedActions)
+	if len(actions) == 0 {
+		return ErrInvalidCapability("allowedActions")
+	}
+
+	request.AllowedActions = actions
+	return nil
+}
+
+func normalizeActions(actions []string) []string {
+	if len(actions) == 0 {
+		return nil
+	}
+
+	normalized := make([]string, 0, len(actions))
+	for _, action := range actions {
+		normalized = append(normalized, strings.ToLower(strings.TrimSpace(action)))
+	}
+	slices.Sort(normalized)
+
+	unique := normalized[:0]
+	for _, action := range normalized {
+		if action == "" {
+			continue
+		}
+		if len(unique) == 0 || unique[len(unique)-1] != action {
+			unique = append(unique, action)
+		}
+	}
+
+	return unique
+}
+
+func accountPrefix(accountID string) string {
+	return fmt.Sprintf("accounts/%s/", accountID)
+}
+
+func isValidIdentitySegment(value string) bool {
+	return value != "" && !strings.Contains(value, "/") && !strings.Contains(value, "..")
+}
+
+func isSortedUniqueActions(actions []string) bool {
+	if len(actions) == 0 {
+		return false
+	}
+	for i := 1; i < len(actions); i++ {
+		if actions[i-1] >= actions[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAction(actions []string, want string) bool {
+	return slices.Contains(actions, strings.ToLower(want))
+}
+
+func isNormalizedObjectKey(key string) bool {
+	if key == "" || strings.HasPrefix(key, "/") || strings.HasSuffix(key, "/") {
+		return false
+	}
+	parts := strings.Split(key, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+type invalidCapabilityError string
+
+func (e invalidCapabilityError) Error() string {
+	return fmt.Sprintf("invalid access capability field: %s", string(e))
+}
+
+func ErrInvalidCapability(field string) error {
+	return invalidCapabilityError(field)
+}
+
+type forbiddenAccessError string
+
+func (e forbiddenAccessError) Error() string {
+	return fmt.Sprintf("forbidden access: %s", string(e))
+}
+
+func ErrForbiddenAccess(reason string) error {
+	return forbiddenAccessError(reason)
+}
+
+type expiredCapabilityError struct{}
+
+func (expiredCapabilityError) Error() string {
+	return "expired access capability"
+}
+
+func ErrExpiredCapability() error {
+	return expiredCapabilityError{}
+}

--- a/internal/auth/access_test.go
+++ b/internal/auth/access_test.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestIssueAndVerifyAccountCapability(t *testing.T) {
+	signer := newTestSigner(t, time.Date(2026, 4, 6, 8, 0, 0, 0, time.UTC))
+
+	signed, err := signer.IssueAccountCapability(AccountAccessRequest{
+		AccountID:      "acct-dev-001",
+		DeviceID:       "dev-web-001",
+		Bucket:         "safe-dev",
+		AllowedActions: []string{ActionPut, ActionGet},
+		TTL:            5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("issue capability: %v", err)
+	}
+
+	if signed.Capability.Prefix != "accounts/acct-dev-001/" {
+		t.Fatalf("unexpected prefix: %s", signed.Capability.Prefix)
+	}
+	if len(signed.Capability.AllowedActions) != 2 || signed.Capability.AllowedActions[0] != ActionGet || signed.Capability.AllowedActions[1] != ActionPut {
+		t.Fatalf("unexpected actions: %#v", signed.Capability.AllowedActions)
+	}
+
+	capability, err := signer.VerifyAccountAccess(signed.Token, AccessCheck{
+		Bucket: "safe-dev",
+		Action: ActionPut,
+		Key:    "accounts/acct-dev-001/collections/vault/items/item-1.json",
+		Now:    time.Date(2026, 4, 6, 8, 2, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("verify capability: %v", err)
+	}
+	if capability.DeviceID != "dev-web-001" {
+		t.Fatalf("unexpected device: %s", capability.DeviceID)
+	}
+}
+
+func TestVerifyAccountAccessRejectsPrefixOverreach(t *testing.T) {
+	signer := newTestSigner(t, time.Date(2026, 4, 6, 8, 0, 0, 0, time.UTC))
+	signed := mustIssueCapability(t, signer)
+
+	_, err := signer.VerifyAccountAccess(signed.Token, AccessCheck{
+		Bucket: "safe-dev",
+		Action: ActionGet,
+		Key:    "accounts/acct-other-001/collections/vault/items/item-1.json",
+		Now:    time.Date(2026, 4, 6, 8, 1, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("expected prefix overreach rejection")
+	}
+}
+
+func TestVerifyAccountAccessRejectsMethodEscalation(t *testing.T) {
+	signer := newTestSigner(t, time.Date(2026, 4, 6, 8, 0, 0, 0, time.UTC))
+	signed, err := signer.IssueAccountCapability(AccountAccessRequest{
+		AccountID:      "acct-dev-001",
+		DeviceID:       "dev-web-001",
+		Bucket:         "safe-dev",
+		AllowedActions: []string{ActionGet},
+		TTL:            5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("issue capability: %v", err)
+	}
+
+	_, err = signer.VerifyAccountAccess(signed.Token, AccessCheck{
+		Bucket: "safe-dev",
+		Action: ActionPut,
+		Key:    "accounts/acct-dev-001/collections/vault/items/item-1.json",
+		Now:    time.Date(2026, 4, 6, 8, 1, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("expected method escalation rejection")
+	}
+}
+
+func TestVerifyAccountAccessRejectsExpiredCapability(t *testing.T) {
+	signer := newTestSigner(t, time.Date(2026, 4, 6, 8, 0, 0, 0, time.UTC))
+	signed := mustIssueCapability(t, signer)
+
+	_, err := signer.VerifyAccountAccess(signed.Token, AccessCheck{
+		Bucket: "safe-dev",
+		Action: ActionGet,
+		Key:    "accounts/acct-dev-001/collections/vault/items/item-1.json",
+		Now:    time.Date(2026, 4, 6, 8, 6, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, ErrExpiredCapability()) {
+		t.Fatalf("expected expired capability, got %v", err)
+	}
+}
+
+func TestVerifyAccountAccessRejectsListByDefault(t *testing.T) {
+	signer := newTestSigner(t, time.Date(2026, 4, 6, 8, 0, 0, 0, time.UTC))
+	signed := mustIssueCapability(t, signer)
+
+	_, err := signer.VerifyAccountAccess(signed.Token, AccessCheck{
+		Bucket: "safe-dev",
+		Action: ActionList,
+		Key:    "accounts/acct-dev-001/collections/vault/events",
+		Now:    time.Date(2026, 4, 6, 8, 1, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("expected list rejection")
+	}
+}
+
+func TestValidateActiveDevice(t *testing.T) {
+	err := ValidateActiveDevice("acct-dev-001", "dev-web-001", func(accountID, deviceID string) (bool, error) {
+		if accountID != "acct-dev-001" || deviceID != "dev-web-001" {
+			t.Fatalf("unexpected lookup args: %s %s", accountID, deviceID)
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("validate active device: %v", err)
+	}
+
+	err = ValidateActiveDevice("acct-dev-001", "dev-revoked-001", func(accountID, deviceID string) (bool, error) {
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("expected revoked device rejection")
+	}
+}
+
+func newTestSigner(t *testing.T, now time.Time) *CapabilitySigner {
+	t.Helper()
+
+	signer, err := NewCapabilitySigner("test-key", []byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	signer.now = func() time.Time { return now }
+	return signer
+}
+
+func mustIssueCapability(t *testing.T, signer *CapabilitySigner) SignedCapability {
+	t.Helper()
+
+	signed, err := signer.IssueAccountCapability(AccountAccessRequest{
+		AccountID:      "acct-dev-001",
+		DeviceID:       "dev-web-001",
+		Bucket:         "safe-dev",
+		AllowedActions: []string{ActionGet, ActionPut},
+		TTL:            5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("issue capability: %v", err)
+	}
+
+	return signed
+}


### PR DESCRIPTION
Refs #32
Milestone: M2 - Multi-Device Single-User Sync Foundations

## Summary
- freeze I9 for signed account-scoped access capabilities in repo docs
- add internal auth helpers to issue and verify short-lived account-path capabilities
- add POST /v1/access/account to the control plane with coverage for identity mismatch and explicit list access

## Verification
- go test ./cmd/control-plane/... ./internal/auth/...
- go test ./...