### PR TITLE
feat(storage): export DeviceRecordKey and device record helpers for W17 (refs #37)

### DIFF
--- a/internal/storage/keys.go
+++ b/internal/storage/keys.go
@@ -37,3 +37,7 @@ func SecretMaterialKey(accountID, collectionID, secretRef string) string {
 	encodedRef := base64.RawURLEncoding.EncodeToString([]byte(secretRef))
 	return fmt.Sprintf("accounts/%s/collections/%s/secrets/%s.txt", accountID, collectionID, encodedRef)
 }
+
+func DeviceRecordKey(accountID, deviceID string) string {
+	return fmt.Sprintf("accounts/%s/devices/%s.json", accountID, deviceID)
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -211,6 +211,29 @@ func LoadLocalUnlockRecord(store ObjectStore, accountID string) (domain.LocalUnl
 	return domain.ParseLocalUnlockRecordJSON(payload)
 }
 
+func StoreLocalDeviceRecord(store ObjectStore, record domain.LocalDeviceRecord) (string, error) {
+	payload, err := record.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+
+	key := DeviceRecordKey(record.AccountID, record.DeviceID)
+	if err := store.Put(key, payload); err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func LoadLocalDeviceRecord(store ObjectStore, accountID, deviceID string) (domain.LocalDeviceRecord, error) {
+	payload, err := store.Get(DeviceRecordKey(accountID, deviceID))
+	if err != nil {
+		return domain.LocalDeviceRecord{}, err
+	}
+
+	return domain.ParseLocalDeviceRecordJSON(payload)
+}
+
 func StoreSecretMaterialBytes(store ObjectStore, accountID, collectionID, secretRef string, secret []byte) (string, error) {
 	key := SecretMaterialKey(accountID, collectionID, secretRef)
 	if err := store.Put(key, secret); err != nil {

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -260,6 +260,39 @@ func TestStoreAndLoadSecretMaterial(t *testing.T) {
 	}
 }
 
+func TestStoreAndLoadLocalDeviceRecord(t *testing.T) {
+	store := NewMemoryObjectStore()
+	record := domain.LocalDeviceRecord{
+		SchemaVersion:       1,
+		AccountID:           "acct-dev-001",
+		DeviceID:            "dev-cli-001",
+		Label:               "Primary CLI",
+		DeviceType:          "cli",
+		SigningPublicKey:     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		EncryptionPublicKey: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		CreatedAt:           "2026-04-06T00:00:00Z",
+		Status:              "active",
+	}
+
+	key, err := StoreLocalDeviceRecord(store, record)
+	if err != nil {
+		t.Fatalf("store device record: %v", err)
+	}
+
+	if key != "accounts/acct-dev-001/devices/dev-cli-001.json" {
+		t.Fatalf("unexpected device record key: %s", key)
+	}
+
+	loaded, err := LoadLocalDeviceRecord(store, "acct-dev-001", "dev-cli-001")
+	if err != nil {
+		t.Fatalf("load device record: %v", err)
+	}
+
+	if loaded.DeviceID != record.DeviceID || loaded.AccountID != record.AccountID || loaded.Status != record.Status {
+		t.Fatalf("unexpected loaded device record: %+v", loaded)
+	}
+}
+
 // TestCommitVaultMutationFull verifies that CommitVaultMutation writes all
 // records (secret, item, event, head) and that each can be read back.
 func TestCommitVaultMutationFull(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `DeviceRecordKey(accountID, deviceID string) string` to `internal/storage/keys.go` — the device record object key was previously only accessible as a private `deviceRecordKey` in `internal/sync/writer.go`
- Add `StoreLocalDeviceRecord` and `LoadLocalDeviceRecord` helpers to `internal/storage/store.go` — consistent with the existing pattern for all other record types
- Add `TestStoreAndLoadLocalDeviceRecord` to verify key format and round-trip serialization

## Why

W17 client wiring (`cmd/safe`) needs to publish a device record to the shared S3 store so that `SyncWriter` head verification can resolve the authoring device on the reading side. Without an exported key helper, Codex would have to hardcode the path format in client code or reference the sync-internal private function.

## Write scope

- `internal/storage/**` (Engineer2 scope)

## Test plan

- [x] `go test ./internal/storage/...` — all existing tests pass, new test passes
- [x] `go test ./...` — full suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)