### PR TITLE
feat(storage): device listing and enrollment request/bundle helpers (refs #53)

### DIFF
--- a/internal/domain/device.go
+++ b/internal/domain/device.go
@@ -146,6 +146,92 @@ func ParseDeviceEnrollmentBundleJSON(data []byte) (DeviceEnrollmentBundle, error
 	return b, nil
 }
 
+// DeviceEnrollmentRequest is published by a new device to request enrollment.
+// An existing trusted device reads this record, creates a DeviceEnrollmentBundle,
+// and writes the bundle at the corresponding enrollment bundle path.
+// Stored at accounts/<accountID>/enrollments/<deviceID>/request.json.
+type DeviceEnrollmentRequest struct {
+	SchemaVersion       int    `json:"schemaVersion"`
+	AccountID           string `json:"accountId"`
+	DeviceID            string `json:"deviceId"`
+	Label               string `json:"label"`
+	DeviceType          string `json:"deviceType"`
+	EncryptionPublicKey string `json:"encryptionPublicKey"`
+	RequestedAt         string `json:"requestedAt"`
+}
+
+func (r DeviceEnrollmentRequest) Validate() error {
+	if r.SchemaVersion != 1 {
+		return ErrInvalidDeviceEnrollmentRequest("schemaVersion")
+	}
+	if r.AccountID == "" {
+		return ErrInvalidDeviceEnrollmentRequest("accountId")
+	}
+	if r.DeviceID == "" {
+		return ErrInvalidDeviceEnrollmentRequest("deviceId")
+	}
+	if r.Label == "" {
+		return ErrInvalidDeviceEnrollmentRequest("label")
+	}
+	if r.DeviceType != "cli" && r.DeviceType != "web" {
+		return ErrInvalidDeviceEnrollmentRequest("deviceType")
+	}
+	if !isValidRawBase64(r.EncryptionPublicKey) {
+		return ErrInvalidDeviceEnrollmentRequest("encryptionPublicKey")
+	}
+	if r.RequestedAt == "" {
+		return ErrInvalidDeviceEnrollmentRequest("requestedAt")
+	}
+	return nil
+}
+
+func (r DeviceEnrollmentRequest) CanonicalJSON() ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+
+	type canonical struct {
+		SchemaVersion       int    `json:"schemaVersion"`
+		AccountID           string `json:"accountId"`
+		DeviceID            string `json:"deviceId"`
+		Label               string `json:"label"`
+		DeviceType          string `json:"deviceType"`
+		EncryptionPublicKey string `json:"encryptionPublicKey"`
+		RequestedAt         string `json:"requestedAt"`
+	}
+
+	return json.Marshal(canonical{
+		SchemaVersion:       r.SchemaVersion,
+		AccountID:           r.AccountID,
+		DeviceID:            r.DeviceID,
+		Label:               r.Label,
+		DeviceType:          r.DeviceType,
+		EncryptionPublicKey: r.EncryptionPublicKey,
+		RequestedAt:         r.RequestedAt,
+	})
+}
+
+func ParseDeviceEnrollmentRequestJSON(data []byte) (DeviceEnrollmentRequest, error) {
+	var r DeviceEnrollmentRequest
+	if err := json.Unmarshal(data, &r); err != nil {
+		return DeviceEnrollmentRequest{}, err
+	}
+	if err := r.Validate(); err != nil {
+		return DeviceEnrollmentRequest{}, err
+	}
+	return r, nil
+}
+
+type invalidDeviceEnrollmentRequestError string
+
+func (e invalidDeviceEnrollmentRequestError) Error() string {
+	return fmt.Sprintf("invalid device enrollment request field: %s", string(e))
+}
+
+func ErrInvalidDeviceEnrollmentRequest(field string) error {
+	return invalidDeviceEnrollmentRequestError(field)
+}
+
 type invalidLocalDeviceRecordError string
 
 func (e invalidLocalDeviceRecordError) Error() string {

--- a/internal/storage/keys.go
+++ b/internal/storage/keys.go
@@ -41,3 +41,19 @@ func SecretMaterialKey(accountID, collectionID, secretRef string) string {
 func DeviceRecordKey(accountID, deviceID string) string {
 	return fmt.Sprintf("accounts/%s/devices/%s.json", accountID, deviceID)
 }
+
+func DeviceListPrefix(accountID string) string {
+	return fmt.Sprintf("accounts/%s/devices/", accountID)
+}
+
+func EnrollmentRequestKey(accountID, deviceID string) string {
+	return fmt.Sprintf("accounts/%s/enrollments/%s/request.json", accountID, deviceID)
+}
+
+func EnrollmentBundleKey(accountID, deviceID string) string {
+	return fmt.Sprintf("accounts/%s/enrollments/%s/bundle.json", accountID, deviceID)
+}
+
+func EnrollmentListPrefix(accountID string) string {
+	return fmt.Sprintf("accounts/%s/enrollments/", accountID)
+}

--- a/internal/storage/keys_test.go
+++ b/internal/storage/keys_test.go
@@ -19,3 +19,35 @@ func TestItemObjectKey(t *testing.T) {
 		t.Fatalf("unexpected item object key\nwant: %s\ngot:  %s", want, got)
 	}
 }
+
+func TestDeviceListPrefix(t *testing.T) {
+	got := DeviceListPrefix("acct-dev-001")
+	want := "accounts/acct-dev-001/devices/"
+	if got != want {
+		t.Fatalf("unexpected device list prefix\nwant: %s\ngot:  %s", want, got)
+	}
+}
+
+func TestEnrollmentRequestKey(t *testing.T) {
+	got := EnrollmentRequestKey("acct-dev-001", "dev-new-001")
+	want := "accounts/acct-dev-001/enrollments/dev-new-001/request.json"
+	if got != want {
+		t.Fatalf("unexpected enrollment request key\nwant: %s\ngot:  %s", want, got)
+	}
+}
+
+func TestEnrollmentBundleKey(t *testing.T) {
+	got := EnrollmentBundleKey("acct-dev-001", "dev-new-001")
+	want := "accounts/acct-dev-001/enrollments/dev-new-001/bundle.json"
+	if got != want {
+		t.Fatalf("unexpected enrollment bundle key\nwant: %s\ngot:  %s", want, got)
+	}
+}
+
+func TestEnrollmentListPrefix(t *testing.T) {
+	got := EnrollmentListPrefix("acct-dev-001")
+	want := "accounts/acct-dev-001/enrollments/"
+	if got != want {
+		t.Fatalf("unexpected enrollment list prefix\nwant: %s\ngot:  %s", want, got)
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -232,6 +233,107 @@ func LoadLocalDeviceRecord(store ObjectStore, accountID, deviceID string) (domai
 	}
 
 	return domain.ParseLocalDeviceRecordJSON(payload)
+}
+
+// ListDeviceRecords returns all device records stored under the account's device prefix,
+// sorted lexicographically by key. Returns an empty slice (not an error) when no devices exist.
+func ListDeviceRecords(store ObjectStore, accountID string) ([]domain.LocalDeviceRecord, error) {
+	keys, err := store.List(DeviceListPrefix(accountID))
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]domain.LocalDeviceRecord, 0, len(keys))
+	for _, key := range keys {
+		payload, err := store.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		record, err := domain.ParseLocalDeviceRecordJSON(payload)
+		if err != nil {
+			return nil, fmt.Errorf("parse device record at %s: %w", key, err)
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+// StoreEnrollmentRequest persists a new device's enrollment request at the
+// canonical enrollment request path for the device.
+func StoreEnrollmentRequest(store ObjectStore, request domain.DeviceEnrollmentRequest) (string, error) {
+	payload, err := request.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+
+	key := EnrollmentRequestKey(request.AccountID, request.DeviceID)
+	if err := store.Put(key, payload); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+// LoadEnrollmentRequest loads the pending enrollment request for the given device.
+func LoadEnrollmentRequest(store ObjectStore, accountID, deviceID string) (domain.DeviceEnrollmentRequest, error) {
+	payload, err := store.Get(EnrollmentRequestKey(accountID, deviceID))
+	if err != nil {
+		return domain.DeviceEnrollmentRequest{}, err
+	}
+	return domain.ParseDeviceEnrollmentRequestJSON(payload)
+}
+
+// ListPendingEnrollments returns enrollment requests for all devices that have
+// a request but no bundle yet. These are devices awaiting approval.
+func ListPendingEnrollments(store ObjectStore, accountID string) ([]domain.DeviceEnrollmentRequest, error) {
+	keys, err := store.List(EnrollmentListPrefix(accountID))
+	if err != nil {
+		return nil, err
+	}
+
+	requests := make([]domain.DeviceEnrollmentRequest, 0)
+	for _, key := range keys {
+		if !strings.HasSuffix(key, "/request.json") {
+			continue
+		}
+		payload, err := store.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		request, err := domain.ParseDeviceEnrollmentRequestJSON(payload)
+		if err != nil {
+			return nil, fmt.Errorf("parse enrollment request at %s: %w", key, err)
+		}
+		// Only include requests that have no bundle yet.
+		bundleKey := EnrollmentBundleKey(accountID, request.DeviceID)
+		_, bundleErr := store.Get(bundleKey)
+		if IsObjectNotFound(bundleErr) {
+			requests = append(requests, request)
+		}
+	}
+	return requests, nil
+}
+
+// StoreEnrollmentBundle persists the enrollment bundle created by an approving device.
+func StoreEnrollmentBundle(store ObjectStore, bundle domain.DeviceEnrollmentBundle) (string, error) {
+	payload, err := json.Marshal(bundle)
+	if err != nil {
+		return "", err
+	}
+
+	key := EnrollmentBundleKey(bundle.AccountID, bundle.DeviceID)
+	if err := store.Put(key, payload); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+// LoadEnrollmentBundle loads the enrollment bundle for a device waiting to complete enrollment.
+func LoadEnrollmentBundle(store ObjectStore, accountID, deviceID string) (domain.DeviceEnrollmentBundle, error) {
+	payload, err := store.Get(EnrollmentBundleKey(accountID, deviceID))
+	if err != nil {
+		return domain.DeviceEnrollmentBundle{}, err
+	}
+	return domain.ParseDeviceEnrollmentBundleJSON(payload)
 }
 
 func StoreSecretMaterialBytes(store ObjectStore, accountID, collectionID, secretRef string, secret []byte) (string, error) {

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -447,3 +447,164 @@ func (s *failOnKeyStore) Put(key string, value []byte) error {
 	}
 	return s.ObjectStore.Put(key, value)
 }
+
+// --- W22 device listing and enrollment helpers ---
+
+func testDeviceRecord(accountID, deviceID, deviceType string) domain.LocalDeviceRecord {
+	return domain.LocalDeviceRecord{
+		SchemaVersion:       1,
+		AccountID:           accountID,
+		DeviceID:            deviceID,
+		Label:               "Test Device",
+		DeviceType:          deviceType,
+		SigningPublicKey:     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		EncryptionPublicKey: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		CreatedAt:           "2026-04-06T00:00:00Z",
+		Status:              "active",
+	}
+}
+
+func testEnrollmentRequest(accountID, deviceID string) domain.DeviceEnrollmentRequest {
+	return domain.DeviceEnrollmentRequest{
+		SchemaVersion:       1,
+		AccountID:           accountID,
+		DeviceID:            deviceID,
+		Label:               "New Device",
+		DeviceType:          "cli",
+		EncryptionPublicKey: "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+		RequestedAt:         "2026-04-06T10:00:00Z",
+	}
+}
+
+func TestListDeviceRecordsEmpty(t *testing.T) {
+	store := NewMemoryObjectStore()
+	records, err := ListDeviceRecords(store, "acct-test")
+	if err != nil {
+		t.Fatalf("list devices: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("expected empty list, got %d records", len(records))
+	}
+}
+
+func TestListDeviceRecordsMultiple(t *testing.T) {
+	store := NewMemoryObjectStore()
+	acct := "acct-test"
+	r1 := testDeviceRecord(acct, "dev-001", "cli")
+	r2 := testDeviceRecord(acct, "dev-002", "web")
+	if _, err := StoreLocalDeviceRecord(store, r1); err != nil {
+		t.Fatalf("store r1: %v", err)
+	}
+	if _, err := StoreLocalDeviceRecord(store, r2); err != nil {
+		t.Fatalf("store r2: %v", err)
+	}
+	// Unrelated account must not appear.
+	r3 := testDeviceRecord("other-acct", "dev-001", "cli")
+	if _, err := StoreLocalDeviceRecord(store, r3); err != nil {
+		t.Fatalf("store r3: %v", err)
+	}
+
+	records, err := ListDeviceRecords(store, acct)
+	if err != nil {
+		t.Fatalf("list devices: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+}
+
+func TestStoreAndLoadEnrollmentRequest(t *testing.T) {
+	store := NewMemoryObjectStore()
+	req := testEnrollmentRequest("acct-test", "dev-new-001")
+
+	key, err := StoreEnrollmentRequest(store, req)
+	if err != nil {
+		t.Fatalf("store enrollment request: %v", err)
+	}
+	want := "accounts/acct-test/enrollments/dev-new-001/request.json"
+	if key != want {
+		t.Fatalf("unexpected key: got %s, want %s", key, want)
+	}
+
+	loaded, err := LoadEnrollmentRequest(store, "acct-test", "dev-new-001")
+	if err != nil {
+		t.Fatalf("load enrollment request: %v", err)
+	}
+	if loaded.DeviceID != req.DeviceID || loaded.AccountID != req.AccountID {
+		t.Fatalf("loaded request mismatch: %+v", loaded)
+	}
+}
+
+func TestListPendingEnrollmentsFiltersApproved(t *testing.T) {
+	store := NewMemoryObjectStore()
+	acct := "acct-test"
+
+	// Two pending requests.
+	req1 := testEnrollmentRequest(acct, "dev-pending-001")
+	req2 := testEnrollmentRequest(acct, "dev-pending-002")
+	if _, err := StoreEnrollmentRequest(store, req1); err != nil {
+		t.Fatalf("store req1: %v", err)
+	}
+	if _, err := StoreEnrollmentRequest(store, req2); err != nil {
+		t.Fatalf("store req2: %v", err)
+	}
+
+	// Approve req2 by writing a bundle — it should no longer appear as pending.
+	bundle := domain.DeviceEnrollmentBundle{
+		SchemaVersion: 1,
+		AccountID:     acct,
+		DeviceID:      "dev-pending-002",
+		WrappedKey: domain.DeviceEnrollmentWrappedKey{
+			Algorithm:          "x25519-hkdf-aes-256-gcm",
+			EphemeralPublicKey: "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+			Nonce:              "EEEEEEEEEEEEEEEEEEE",
+			Ciphertext:         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+		},
+	}
+	if _, err := StoreEnrollmentBundle(store, bundle); err != nil {
+		t.Fatalf("store bundle: %v", err)
+	}
+
+	pending, err := ListPendingEnrollments(store, acct)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending enrollment, got %d", len(pending))
+	}
+	if pending[0].DeviceID != "dev-pending-001" {
+		t.Fatalf("unexpected pending device: %s", pending[0].DeviceID)
+	}
+}
+
+func TestStoreAndLoadEnrollmentBundle(t *testing.T) {
+	store := NewMemoryObjectStore()
+	bundle := domain.DeviceEnrollmentBundle{
+		SchemaVersion: 1,
+		AccountID:     "acct-test",
+		DeviceID:      "dev-new-001",
+		WrappedKey: domain.DeviceEnrollmentWrappedKey{
+			Algorithm:          "x25519-hkdf-aes-256-gcm",
+			EphemeralPublicKey: "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+			Nonce:              "EEEEEEEEEEEEEEEEEEE",
+			Ciphertext:         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+		},
+	}
+
+	key, err := StoreEnrollmentBundle(store, bundle)
+	if err != nil {
+		t.Fatalf("store bundle: %v", err)
+	}
+	want := "accounts/acct-test/enrollments/dev-new-001/bundle.json"
+	if key != want {
+		t.Fatalf("unexpected key: got %s, want %s", key, want)
+	}
+
+	loaded, err := LoadEnrollmentBundle(store, "acct-test", "dev-new-001")
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	if loaded.DeviceID != bundle.DeviceID || loaded.AccountID != bundle.AccountID {
+		t.Fatalf("loaded bundle mismatch: %+v", loaded)
+	}
+}


### PR DESCRIPTION
Refs #53

## Summary
- `DeviceEnrollmentRequest` domain type (Validate / CanonicalJSON / Parse) — carries the new device's X25519 public key and metadata before an approving device has seen it
- New storage keys: `DeviceListPrefix`, `EnrollmentRequestKey`, `EnrollmentBundleKey`, `EnrollmentListPrefix`
- New storage helpers: `ListDeviceRecords`, `StoreEnrollmentRequest`, `LoadEnrollmentRequest`, `ListPendingEnrollments`, `StoreEnrollmentBundle`, `LoadEnrollmentBundle`
- `ListPendingEnrollments` automatically filters out requests that already have an approved bundle
- Full unit tests for all new helpers and key functions

## Why now
W22 (web sync + device management) needs device listing and the enrollment request/bundle path before Codex can wire the device management UX. This is Engineer2's write scope (`internal/storage/**`, `internal/domain/**`) and unblocks W22 without touching `apps/web/**` or `cmd/safe/**`.

## Test plan
- `go test ./internal/storage/... ./internal/domain/...` — all pass
- `go test ./...` — full suite passes