### PR TITLE
feat(web): add sync and device management surface

### DIFF
--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -2,6 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import http from "node:http";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import {
   addApiKeyToVaultWorkspace,
@@ -33,6 +35,9 @@ type SessionState = {
   remoteAccess: AccountAccessResponse | null;
   accountKey: Buffer | null;
   pendingOnboarding: PreparedFirstUse | null;
+  pendingPassword: string | null;
+  vaultPassword: string | null;
+  flash: string | null;
 };
 
 type ControlPlaneSession = {
@@ -63,6 +68,38 @@ type AccountAccessResponse = {
   capability: AccountAccessCapability;
 };
 
+type SafeCommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+type SafeCommandRunner = (
+  args: string[],
+  env: NodeJS.ProcessEnv,
+) => Promise<SafeCommandResult>;
+
+type DeviceRecord = {
+  schemaVersion: number;
+  accountId: string;
+  deviceId: string;
+  label: string;
+  deviceType: string;
+  signingPublicKey: string;
+  encryptionPublicKey: string;
+  createdAt: string;
+  status: string;
+};
+
+type EnrollmentRequest = {
+  schemaVersion: number;
+  accountId: string;
+  deviceId: string;
+  label: string;
+  deviceType: string;
+  encryptionPublicKey: string;
+  requestedAt: string;
+};
+
 export type WebClientServerOptions = {
   dataDir?: string;
   now?: () => Date;
@@ -70,11 +107,13 @@ export type WebClientServerOptions = {
   resolveRemoteAccess?: (
     identity: ClientIdentity,
   ) => Promise<AccountAccessResponse | null>;
+  runSafeCommand?: SafeCommandRunner;
 };
 
 export function createWebClientServer(
   options: WebClientServerOptions = {},
 ): http.RequestListener {
+  const runSafeCommand = options.runSafeCommand ?? defaultRunSafeCommand;
   const dataDir =
     options.dataDir ??
     process.env.SAFE_WEB_DATA_DIR ??
@@ -138,6 +177,9 @@ export function createWebClientServer(
       session.remoteAccess = await resolveRemoteAccess(session.identity);
       session.accountKey = null;
       session.pendingOnboarding = null;
+      session.pendingPassword = null;
+      session.vaultPassword = null;
+      session.flash = null;
       redirect(response, "/unlock");
       return;
     }
@@ -181,6 +223,7 @@ export function createWebClientServer(
       try {
         if (firstUse) {
           session.pendingOnboarding = store.prepareFirstUse(session.identity, password);
+          session.pendingPassword = password;
           session.accountKey = null;
           redirect(response, "/onboarding/recovery");
           return;
@@ -188,7 +231,9 @@ export function createWebClientServer(
 
         const unlocked = await store.unlock(session.identity, password);
         session.pendingOnboarding = null;
+        session.pendingPassword = null;
         session.accountKey = unlocked.accountKey;
+        session.vaultPassword = password;
         redirect(response, "/vault");
         return;
       } catch {
@@ -250,13 +295,16 @@ export function createWebClientServer(
         session.pendingOnboarding,
       );
       session.accountKey = unlocked.accountKey;
+      session.vaultPassword = session.pendingPassword;
       session.pendingOnboarding = null;
+      session.pendingPassword = null;
       redirect(response, "/vault");
       return;
     }
 
     if (request.method === "POST" && url.pathname === "/lock") {
       session.accountKey = null;
+      session.vaultPassword = null;
       redirect(response, "/unlock");
       return;
     }
@@ -265,6 +313,9 @@ export function createWebClientServer(
       session.identity = null;
       session.accountKey = null;
       session.pendingOnboarding = null;
+      session.pendingPassword = null;
+      session.vaultPassword = null;
+      session.flash = null;
       redirect(response, "/");
       return;
     }
@@ -279,6 +330,9 @@ export function createWebClientServer(
         session,
         readVaultQuery(url),
       );
+      const flash = session.flash;
+      session.flash = null;
+      const remoteState = await loadRemoteState(session);
       writeHTML(
         response,
         200,
@@ -287,6 +341,10 @@ export function createWebClientServer(
           remoteAccess: session.remoteAccess,
           itemId: url.searchParams.get("item"),
           unlocked,
+          devices: remoteState.devices,
+          pendingEnrollments: remoteState.pendingEnrollments,
+          syncError: remoteState.error,
+          flash,
         }),
       );
       return;
@@ -325,6 +383,10 @@ export function createWebClientServer(
             remoteAccess: session.remoteAccess,
             unlocked,
             itemId: null,
+            devices: [],
+            pendingEnrollments: [],
+            syncError: null,
+            flash: null,
             error:
               error instanceof Error
                 ? error.message
@@ -366,6 +428,10 @@ export function createWebClientServer(
             remoteAccess: session.remoteAccess,
             unlocked,
             itemId: form.get("itemId")?.trim() ?? null,
+            devices: [],
+            pendingEnrollments: [],
+            syncError: null,
+            flash: null,
             error:
               error instanceof Error
                 ? error.message
@@ -408,6 +474,10 @@ export function createWebClientServer(
             remoteAccess: session.remoteAccess,
             unlocked,
             itemId: itemId || null,
+            devices: [],
+            pendingEnrollments: [],
+            syncError: null,
+            flash: null,
             error:
               error instanceof Error
                 ? error.message
@@ -451,6 +521,10 @@ export function createWebClientServer(
             remoteAccess: session.remoteAccess,
             unlocked,
             itemId: itemId || null,
+            devices: [],
+            pendingEnrollments: [],
+            syncError: null,
+            flash: null,
             error:
               error instanceof Error
                 ? error.message
@@ -494,11 +568,101 @@ export function createWebClientServer(
             remoteAccess: session.remoteAccess,
             unlocked,
             itemId: itemId || null,
+            devices: [],
+            pendingEnrollments: [],
+            syncError: null,
+            flash: null,
             error:
               error instanceof Error
                 ? error.message
                 : "Safe could not restore that vault item.",
           }),
+        );
+        return;
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/vault/sync/push") {
+      if (!session.identity || !session.accountKey || !session.vaultPassword) {
+        redirect(response, "/unlock");
+        return;
+      }
+
+      try {
+        await runSafeVaultCommand(session, ["sync", "push"]);
+        session.flash = "Sync push completed against the account remote path.";
+        redirect(response, "/vault");
+        return;
+      } catch (error) {
+        await renderVaultErrorPage(
+          response,
+          session,
+          null,
+          error instanceof Error ? error.message : "Sync push failed.",
+        );
+        return;
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/vault/sync/pull") {
+      if (!session.identity || !session.accountKey || !session.vaultPassword) {
+        redirect(response, "/unlock");
+        return;
+      }
+
+      try {
+        await runSafeVaultCommand(session, ["sync", "pull"]);
+        session.flash = "Sync pull completed and reloaded the local vault snapshot.";
+        redirect(response, "/vault");
+        return;
+      } catch (error) {
+        await renderVaultErrorPage(
+          response,
+          session,
+          null,
+          error instanceof Error ? error.message : "Sync pull failed.",
+        );
+        return;
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/vault/devices/approve") {
+      if (!session.identity || !session.accountKey || !session.vaultPassword) {
+        redirect(response, "/unlock");
+        return;
+      }
+
+      const form = await readForm(request);
+      const deviceId = form.get("deviceId")?.trim() ?? "";
+      if (deviceId === "") {
+        writeHTML(
+          response,
+          400,
+          renderPage({
+            title: "Safe",
+            body: `
+              <section class="panel stack">
+                <p class="eyebrow">Bad Request</p>
+                <h1>Missing device ID</h1>
+                <p><a class="link" href="/vault">Return to vault</a></p>
+              </section>
+            `,
+          }),
+        );
+        return;
+      }
+
+      try {
+        await runSafeVaultCommand(session, ["device", "approve", deviceId]);
+        session.flash = `Approved enrollment request for ${deviceId}.`;
+        redirect(response, "/vault");
+        return;
+      } catch (error) {
+        await renderVaultErrorPage(
+          response,
+          session,
+          null,
+          error instanceof Error ? error.message : "Device approval failed.",
         );
         return;
       }
@@ -536,6 +700,9 @@ export function createWebClientServer(
       remoteAccess: null,
       accountKey: null,
       pendingOnboarding: null,
+      pendingPassword: null,
+      vaultPassword: null,
+      flash: null,
     };
     sessions.set(sessionId, session);
     response.setHeader("Set-Cookie", serializeCookie("safe_web_session", sessionId));
@@ -578,6 +745,76 @@ export function createWebClientServer(
       secretMaterial: result.secretMaterial,
       accountKey: session.accountKey!,
     });
+  }
+
+  async function runSafeVaultCommand(
+    session: SessionState,
+    args: string[],
+  ): Promise<string> {
+    const { stdout, stderr } = await runSafeCommand(
+      ["--json", ...args],
+      buildSafeCommandEnv(dataDir, session),
+    );
+    if (stderr.trim() !== "") {
+      return stdout;
+    }
+    return stdout;
+  }
+
+  async function loadRemoteState(session: SessionState): Promise<{
+    devices: DeviceRecord[];
+    pendingEnrollments: EnrollmentRequest[];
+    error: string | null;
+  }> {
+    if (!session.identity || !session.accountKey || !session.vaultPassword || !session.remoteAccess) {
+      return {
+        devices: [],
+        pendingEnrollments: [],
+        error: null,
+      };
+    }
+
+    try {
+      const [devicesRaw, pendingRaw] = await Promise.all([
+        runSafeVaultCommand(session, ["device", "list"]),
+        runSafeVaultCommand(session, ["device", "pending"]),
+      ]);
+      return {
+        devices: parseDeviceRecords(devicesRaw),
+        pendingEnrollments: parseEnrollmentRequests(pendingRaw),
+        error: null,
+      };
+    } catch (error) {
+      return {
+        devices: [],
+        pendingEnrollments: [],
+        error: error instanceof Error ? error.message : "Remote sync state is unavailable.",
+      };
+    }
+  }
+
+  async function renderVaultErrorPage(
+    response: ServerResponse,
+    session: SessionState,
+    itemId: string | null,
+    error: string,
+  ): Promise<void> {
+    const unlocked = await loadUnlockedVaultForQuery(session, {});
+    const remoteState = await loadRemoteState(session);
+    writeHTML(
+      response,
+      200,
+      renderVaultPage({
+        identity: session.identity!,
+        remoteAccess: session.remoteAccess,
+        unlocked,
+        itemId,
+        devices: remoteState.devices,
+        pendingEnrollments: remoteState.pendingEnrollments,
+        syncError: error,
+        flash: null,
+      }),
+    );
   }
 }
 
@@ -697,6 +934,10 @@ function renderVaultPage(input: {
   remoteAccess: AccountAccessResponse | null;
   unlocked: UnlockedLocalVault;
   itemId: string | null;
+  devices: DeviceRecord[];
+  pendingEnrollments: EnrollmentRequest[];
+  syncError: string | null;
+  flash: string | null;
   error?: string;
 }): string {
   const selectedItemId =
@@ -805,10 +1046,20 @@ function renderVaultPage(input: {
         <p>Prefix <code>${escapeHTML(input.remoteAccess.capability.prefix)}</code></p>
         <p>Actions <code>${escapeHTML(input.remoteAccess.capability.allowedActions.join(", "))}</code></p>
         <p>Expires ${escapeHTML(input.remoteAccess.capability.expiresAt)}</p>
+        <div class="actions">
+          <form method="post" action="/vault/sync/push">
+            <button class="button button-primary" type="submit">Sync push</button>
+          </form>
+          <form method="post" action="/vault/sync/pull">
+            <button class="button button-secondary" type="submit">Sync pull</button>
+          </form>
+        </div>
       </section>
       `
         : ""}
 
+      ${input.flash ? `<p class="success">${escapeHTML(input.flash)}</p>` : ""}
+      ${input.syncError ? `<p class="error">${escapeHTML(input.syncError)}</p>` : ""}
       ${input.error ? `<p class="error">${escapeHTML(input.error)}</p>` : ""}
 
       <section class="panel stack">
@@ -899,6 +1150,62 @@ function renderVaultPage(input: {
                 .join("")}
             </ul>
           `}
+      </section>
+
+      <section class="vault-grid">
+        <section class="panel stack">
+          <p class="eyebrow">Devices</p>
+          <h2>Enrolled devices</h2>
+          ${input.devices.length === 0
+            ? `<p class="empty">No remote device records visible yet.</p>`
+            : `
+              <ul class="item-list">
+                ${input.devices
+                  .map(
+                    (device) => `
+                      <li class="device-row">
+                        <div class="item-link">
+                          <span class="item-kicker">${escapeHTML(device.deviceType)}</span>
+                          <span class="item-title">${escapeHTML(device.label)}</span>
+                          <span class="item-summary">${escapeHTML(device.deviceId)}</span>
+                          <span class="item-meta">Status ${escapeHTML(device.status)} • Created ${escapeHTML(device.createdAt)}</span>
+                        </div>
+                      </li>
+                    `,
+                  )
+                  .join("")}
+              </ul>
+            `}
+        </section>
+
+        <section class="panel stack">
+          <p class="eyebrow">Approvals</p>
+          <h2>Pending enrollment requests</h2>
+          ${input.pendingEnrollments.length === 0
+            ? `<p class="empty">No pending device enrollment requests.</p>`
+            : `
+              <ul class="item-list">
+                ${input.pendingEnrollments
+                  .map(
+                    (request) => `
+                      <li class="deleted-row">
+                        <div class="item-link">
+                          <span class="item-kicker">${escapeHTML(request.deviceType)}</span>
+                          <span class="item-title">${escapeHTML(request.label)}</span>
+                          <span class="item-summary">${escapeHTML(request.deviceId)}</span>
+                          <span class="item-meta">Requested ${escapeHTML(request.requestedAt)}</span>
+                        </div>
+                        <form method="post" action="/vault/devices/approve">
+                          <input name="deviceId" type="hidden" value="${escapeHTML(request.deviceId)}" />
+                          <button class="button button-secondary" type="submit">Approve</button>
+                        </form>
+                      </li>
+                    `,
+                  )
+                  .join("")}
+              </ul>
+            `}
+        </section>
       </section>
     `,
   });
@@ -1491,6 +1798,57 @@ async function updateVaultItemFromForm(
   }
 }
 
+const execFileAsync = promisify(execFile);
+
+async function defaultRunSafeCommand(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<SafeCommandResult> {
+  const result = await execFileAsync("go", ["run", "./cmd/safe", ...args], {
+    cwd: process.cwd(),
+    env,
+  });
+
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function buildSafeCommandEnv(
+  dataDir: string,
+  session: SessionState,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    SAFE_LOCAL_RUNTIME_DIR: path.join(dataDir, "accounts"),
+    SAFE_LOCAL_PASSWORD: session.vaultPassword ?? "",
+  };
+
+  if (session.identity) {
+    env.SAFE_DEVICE_ID = session.identity.deviceId;
+  }
+
+  if (!env.SAFE_CONTROL_PLANE_URL && process.env.SAFE_WEB_CONTROL_PLANE_URL) {
+    env.SAFE_CONTROL_PLANE_URL = process.env.SAFE_WEB_CONTROL_PLANE_URL;
+  }
+  if (!env.SAFE_OAUTH_ACCESS_TOKEN && process.env.SAFE_WEB_OAUTH_ACCESS_TOKEN) {
+    env.SAFE_OAUTH_ACCESS_TOKEN = process.env.SAFE_WEB_OAUTH_ACCESS_TOKEN;
+  }
+
+  return env;
+}
+
+function parseDeviceRecords(raw: string): DeviceRecord[] {
+  const payload = JSON.parse(raw);
+  return Array.isArray(payload) ? payload as DeviceRecord[] : [];
+}
+
+function parseEnrollmentRequests(raw: string): EnrollmentRequest[] {
+  const payload = JSON.parse(raw);
+  return Array.isArray(payload) ? payload as EnrollmentRequest[] : [];
+}
+
 function renderPage(input: {
   title: string;
   body: string;
@@ -1669,13 +2027,14 @@ function renderPage(input: {
         text-transform: uppercase;
         letter-spacing: 0.08em;
       }
-      .item-summary, .empty, .error, dt { color: var(--muted); }
+      .item-summary, .empty, .error, .success, dt { color: var(--muted); }
       .deleted-row {
         display: grid;
         grid-template-columns: 1fr auto;
         gap: 12px;
         align-items: center;
       }
+      .device-row { display: block; }
       .meta-grid, .detail-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
@@ -1701,6 +2060,14 @@ function renderPage(input: {
         border-radius: 16px;
         background: rgba(194, 73, 31, 0.08);
         border: 1px solid rgba(194, 73, 31, 0.16);
+      }
+
+      .success {
+        margin: 0;
+        padding: 12px 14px;
+        border-radius: 16px;
+        background: rgba(70, 126, 84, 0.09);
+        border: 1px solid rgba(70, 126, 84, 0.18);
       }
 
       @media (max-width: 820px) {

--- a/apps/web/test/client-surface.test.mjs
+++ b/apps/web/test/client-surface.test.mjs
@@ -531,3 +531,242 @@ test("web client requests remote account access during identify when control pla
     await rm(dataDir, { recursive: true, force: true });
   }
 });
+
+test("web client surfaces sync actions, enrolled devices, and enrollment approval", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "safe-web-"));
+  const identity = {
+    accountId: "acct-dev-001",
+    deviceId: "dev-web-001",
+    env: "test",
+  };
+  const remoteAccess = {
+    bucket: "safe-test",
+    endpoint: "http://127.0.0.1:4566",
+    region: "us-east-1",
+    keyId: "dev-hmac-v1",
+    token: "signed-token",
+    capability: {
+      version: 1,
+      accountId: "acct-dev-001",
+      deviceId: "dev-web-001",
+      bucket: "safe-test",
+      prefix: "accounts/acct-dev-001/",
+      allowedActions: ["get", "put"],
+      issuedAt: "2026-04-06T08:00:00Z",
+      expiresAt: "2026-04-06T08:05:00Z",
+    },
+  };
+
+  const devices = [
+    {
+      schemaVersion: 1,
+      accountId: "acct-dev-001",
+      deviceId: "dev-cli-001",
+      label: "Safe CLI dev-cli-001",
+      deviceType: "cli",
+      signingPublicKey: "c2ln",
+      encryptionPublicKey: "ZW5j",
+      createdAt: "2026-04-06T07:55:00Z",
+      status: "active",
+    },
+    {
+      schemaVersion: 1,
+      accountId: "acct-dev-001",
+      deviceId: "dev-web-001",
+      label: "Safe Web dev-web-001",
+      deviceType: "web",
+      signingPublicKey: "c2lnMg",
+      encryptionPublicKey: "ZW5jMg",
+      createdAt: "2026-04-06T08:00:00Z",
+      status: "active",
+    },
+  ];
+  const pendingEnrollments = [
+    {
+      schemaVersion: 1,
+      accountId: "acct-dev-001",
+      deviceId: "dev-web-099",
+      label: "Safe Web dev-web-099",
+      deviceType: "web",
+      encryptionPublicKey: "ZW5jLTA5OQ",
+      requestedAt: "2026-04-06T08:10:00Z",
+    },
+  ];
+  const calls = [];
+
+  try {
+    const app = createWebClientServer({
+      dataDir,
+      resolveIdentity: async () => identity,
+      resolveRemoteAccess: async () => remoteAccess,
+      now: () => new Date("2026-04-06T08:12:00Z"),
+      runSafeCommand: async (args, env) => {
+        calls.push({ args, env });
+        assert.match(env.SAFE_LOCAL_RUNTIME_DIR, /accounts$/);
+        assert.equal(env.SAFE_LOCAL_PASSWORD, "correct horse battery staple");
+        assert.equal(env.SAFE_DEVICE_ID, "dev-web-001");
+
+        if (args[0] === "--json" && args[1] === "device" && args[2] === "list") {
+          return {
+            stdout: JSON.stringify(devices),
+            stderr: "",
+          };
+        }
+        if (args[0] === "--json" && args[1] === "device" && args[2] === "pending") {
+          return {
+            stdout: JSON.stringify(pendingEnrollments),
+            stderr: "",
+          };
+        }
+        if (
+          args[0] === "--json" &&
+          args[1] === "device" &&
+          args[2] === "approve" &&
+          args[3] === "dev-web-099"
+        ) {
+          pendingEnrollments.splice(0, pendingEnrollments.length);
+          return {
+            stdout: JSON.stringify({
+              approvedDeviceId: "dev-web-099",
+              accountId: "acct-dev-001",
+              bundleAlgorithm: "x25519-hkdf-aes-256-gcm",
+            }),
+            stderr: "",
+          };
+        }
+        if (args[0] === "--json" && args[1] === "sync" && args[2] === "push") {
+          return {
+            stdout: JSON.stringify({
+              pushed: 1,
+              latestSeq: 3,
+              deviceId: "dev-web-001",
+            }),
+            stderr: "",
+          };
+        }
+        if (args[0] === "--json" && args[1] === "sync" && args[2] === "pull") {
+          return {
+            stdout: JSON.stringify({
+              latestSeq: 3,
+              itemCount: 2,
+            }),
+            stderr: "",
+          };
+        }
+
+        throw new Error(`unexpected safe command ${args.join(" ")}`);
+      },
+    });
+
+    let response = await invoke(app, {
+      method: "POST",
+      url: "/identify",
+    });
+    assert.equal(response.status, 303);
+    const cookie = getSetCookie(response);
+    assert.ok(cookie);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/unlock",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        password: "correct horse battery staple",
+      }),
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/onboarding/recovery");
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/onboarding/recovery",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        confirmed: "yes",
+      }),
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/vault");
+
+    response = await invoke(app, {
+      url: "/vault",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Sync push/);
+    assert.match(response.text, /Sync pull/);
+    assert.match(response.text, /Safe CLI dev-cli-001/);
+    assert.match(response.text, /Safe Web dev-web-099/);
+    assert.match(response.text, /Approve/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/vault/devices/approve",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        deviceId: "dev-web-099",
+      }),
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/vault");
+
+    response = await invoke(app, {
+      url: "/vault",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Approved enrollment request for dev-web-099/);
+    assert.doesNotMatch(response.text, /Safe Web dev-web-099/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/vault/sync/push",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/vault");
+
+    response = await invoke(app, {
+      url: "/vault",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Sync push completed against the account remote path/);
+
+    response = await invoke(app, {
+      method: "POST",
+      url: "/vault/sync/pull",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.location, "/vault");
+
+    response = await invoke(app, {
+      url: "/vault",
+      headers: { cookie },
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.text, /Sync pull completed and reloaded the local vault snapshot/);
+
+    assert.ok(
+      calls.some((call) => call.args[1] === "device" && call.args[2] === "approve"),
+    );
+    assert.ok(
+      calls.some((call) => call.args[1] === "sync" && call.args[2] === "push"),
+    );
+    assert.ok(
+      calls.some((call) => call.args[1] === "sync" && call.args[2] === "pull"),
+    );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});

--- a/cmd/safe/main.go
+++ b/cmd/safe/main.go
@@ -427,29 +427,22 @@ func runDeviceCommand(out io.Writer, state cliState, options cliOptions, args []
 	switch args[0] {
 	case "list":
 		return deviceList(out, state, options)
+	case "pending":
+		return devicePending(out, state, options)
+	case "approve":
+		if len(args) != 2 {
+			return fmt.Errorf("usage: safe device approve <device-id>")
+		}
+		return deviceApprove(out, state, options, args[1])
 	default:
 		return fmt.Errorf("unknown device subcommand: %s", args[0])
 	}
 }
 
 func deviceList(out io.Writer, state cliState, options cliOptions) error {
-	keys, err := state.remoteStore.List(fmt.Sprintf("accounts/%s/devices/", state.session.AccountID))
+	devices, err := storage.ListDeviceRecords(state.remoteStore, state.session.AccountID)
 	if err != nil {
 		return err
-	}
-
-	devices := make([]domain.LocalDeviceRecord, 0, len(keys))
-	for _, key := range keys {
-		payload, err := state.remoteStore.Get(key)
-		if err != nil {
-			return err
-		}
-
-		record, err := domain.ParseLocalDeviceRecordJSON(payload)
-		if err != nil {
-			return err
-		}
-		devices = append(devices, record)
 	}
 
 	sort.Slice(devices, func(i, j int) bool {
@@ -475,6 +468,79 @@ func deviceList(out io.Writer, state cliState, options cliOptions) error {
 			device.CreatedAt,
 		)
 	}
+	return nil
+}
+
+func devicePending(out io.Writer, state cliState, options cliOptions) error {
+	requests, err := storage.ListPendingEnrollments(state.remoteStore, state.session.AccountID)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(requests, func(i, j int) bool {
+		if requests[i].RequestedAt == requests[j].RequestedAt {
+			return requests[i].DeviceID < requests[j].DeviceID
+		}
+		return requests[i].RequestedAt < requests[j].RequestedAt
+	})
+
+	if options.json {
+		return writeJSON(out, requests)
+	}
+
+	fmt.Fprintln(out, "pending enrollments:")
+	for _, request := range requests {
+		fmt.Fprintf(
+			out,
+			"- id=%s label=%s type=%s requestedAt=%s\n",
+			request.DeviceID,
+			request.Label,
+			request.DeviceType,
+			request.RequestedAt,
+		)
+	}
+	return nil
+}
+
+func deviceApprove(out io.Writer, state cliState, options cliOptions, deviceID string) error {
+	request, err := storage.LoadEnrollmentRequest(state.remoteStore, state.session.AccountID, deviceID)
+	if err != nil {
+		return err
+	}
+
+	encryptionPublicKey, err := base64.RawURLEncoding.DecodeString(request.EncryptionPublicKey)
+	if err != nil {
+		return fmt.Errorf("decode enrollment request encryption public key: %w", err)
+	}
+
+	bundle, err := safecrypto.CreateDeviceEnrollmentBundle(
+		request.AccountID,
+		request.DeviceID,
+		encryptionPublicKey,
+		state.accountKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := storage.StoreEnrollmentBundle(state.remoteStore, bundle); err != nil {
+		return err
+	}
+
+	if options.json {
+		return writeJSON(out, struct {
+			ApprovedDeviceID string `json:"approvedDeviceId"`
+			AccountID        string `json:"accountId"`
+			BundleAlgorithm  string `json:"bundleAlgorithm"`
+		}{
+			ApprovedDeviceID: request.DeviceID,
+			AccountID:        request.AccountID,
+			BundleAlgorithm:  bundle.WrappedKey.Algorithm,
+		})
+	}
+
+	fmt.Fprintln(out, "device approval:")
+	fmt.Fprintf(out, "- approved=%s account=%s\n", request.DeviceID, request.AccountID)
 	return nil
 }
 

--- a/cmd/safe/main.go
+++ b/cmd/safe/main.go
@@ -112,6 +112,8 @@ func runWithIO(args []string, in io.Reader, out io.Writer) error {
 		return runSecretCommand(in, out, state, options, args[1:])
 	case "sync":
 		return runSyncCommand(out, state, options, args[1:])
+	case "device":
+		return runDeviceCommand(out, state, options, args[1:])
 	default:
 		return fmt.Errorf("unknown command: %s", args[0])
 	}
@@ -415,6 +417,65 @@ func runSyncCommand(out io.Writer, state cliState, options cliOptions, args []st
 	default:
 		return fmt.Errorf("unknown sync subcommand: %s", args[0])
 	}
+}
+
+func runDeviceCommand(out io.Writer, state cliState, options cliOptions, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("device command requires a subcommand")
+	}
+
+	switch args[0] {
+	case "list":
+		return deviceList(out, state, options)
+	default:
+		return fmt.Errorf("unknown device subcommand: %s", args[0])
+	}
+}
+
+func deviceList(out io.Writer, state cliState, options cliOptions) error {
+	keys, err := state.remoteStore.List(fmt.Sprintf("accounts/%s/devices/", state.session.AccountID))
+	if err != nil {
+		return err
+	}
+
+	devices := make([]domain.LocalDeviceRecord, 0, len(keys))
+	for _, key := range keys {
+		payload, err := state.remoteStore.Get(key)
+		if err != nil {
+			return err
+		}
+
+		record, err := domain.ParseLocalDeviceRecordJSON(payload)
+		if err != nil {
+			return err
+		}
+		devices = append(devices, record)
+	}
+
+	sort.Slice(devices, func(i, j int) bool {
+		if devices[i].CreatedAt == devices[j].CreatedAt {
+			return devices[i].DeviceID < devices[j].DeviceID
+		}
+		return devices[i].CreatedAt < devices[j].CreatedAt
+	})
+
+	if options.json {
+		return writeJSON(out, devices)
+	}
+
+	fmt.Fprintln(out, "devices:")
+	for _, device := range devices {
+		fmt.Fprintf(
+			out,
+			"- id=%s label=%s type=%s status=%s createdAt=%s\n",
+			device.DeviceID,
+			device.Label,
+			device.DeviceType,
+			device.Status,
+			device.CreatedAt,
+		)
+	}
+	return nil
 }
 
 func secretList(out io.Writer, state cliState, options cliOptions) error {

--- a/cmd/safe/main_test.go
+++ b/cmd/safe/main_test.go
@@ -421,6 +421,62 @@ func TestSyncPushPullAcrossTwoDevices(t *testing.T) {
 	})
 }
 
+func TestDeviceListReturnsRemoteDeviceRecords(t *testing.T) {
+	withEmptyBootstrap(t, func(_ string) {
+		state, err := bootstrapCLIState()
+		if err != nil {
+			t.Fatalf("bootstrap state: %v", err)
+		}
+
+		sharedRemote := storage.NewMemoryObjectStoreWithCAS()
+		state.remoteStore = sharedRemote
+		state.session.DeviceID = "dev-cli-001"
+		state.accountConfig.DeviceIDs = []string{"dev-cli-001"}
+
+		material, err := loadOrCreateLocalDeviceMaterial(state)
+		if err != nil {
+			t.Fatalf("load or create local device material: %v", err)
+		}
+		if err := ensureRemoteDeviceRecord(state, material); err != nil {
+			t.Fatalf("ensure remote device record: %v", err)
+		}
+
+		otherKeys, err := safecrypto.GenerateDeviceKeyPair()
+		if err != nil {
+			t.Fatalf("generate device key pair: %v", err)
+		}
+		otherRecord, err := safecrypto.CreateDeviceRecord(
+			state.session.AccountID,
+			"dev-web-002",
+			"Safe Web dev-web-002",
+			"web",
+			otherKeys,
+		)
+		if err != nil {
+			t.Fatalf("create other device record: %v", err)
+		}
+		if _, err := storage.StoreLocalDeviceRecord(sharedRemote, otherRecord); err != nil {
+			t.Fatalf("store other device record: %v", err)
+		}
+
+		var output bytes.Buffer
+		if err := deviceList(&output, state, cliOptions{json: true}); err != nil {
+			t.Fatalf("device list: %v", err)
+		}
+
+		var records []domain.LocalDeviceRecord
+		if err := json.Unmarshal(output.Bytes(), &records); err != nil {
+			t.Fatalf("decode device list: %v", err)
+		}
+		if len(records) != 2 {
+			t.Fatalf("expected 2 device records, got %d", len(records))
+		}
+		if records[0].DeviceID != "dev-cli-001" || records[1].DeviceID != "dev-web-002" {
+			t.Fatalf("unexpected device list ordering or contents: %+v", records)
+		}
+	})
+}
+
 func TestSyncPullRejectsTamperedRemoteHead(t *testing.T) {
 	withEmptyBootstrap(t, func(_ string) {
 		writerState, err := bootstrapCLIState()

--- a/cmd/safe/main_test.go
+++ b/cmd/safe/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	safecrypto "github.com/ndelorme/safe/internal/crypto"
 	"github.com/ndelorme/safe/internal/domain"
 	"github.com/ndelorme/safe/internal/storage"
 	safesync "github.com/ndelorme/safe/internal/sync"
@@ -473,6 +475,131 @@ func TestDeviceListReturnsRemoteDeviceRecords(t *testing.T) {
 		}
 		if records[0].DeviceID != "dev-cli-001" || records[1].DeviceID != "dev-web-002" {
 			t.Fatalf("unexpected device list ordering or contents: %+v", records)
+		}
+	})
+}
+
+func TestDevicePendingReturnsUnapprovedEnrollmentRequests(t *testing.T) {
+	withEmptyBootstrap(t, func(_ string) {
+		state, err := bootstrapCLIState()
+		if err != nil {
+			t.Fatalf("bootstrap state: %v", err)
+		}
+
+		sharedRemote := storage.NewMemoryObjectStoreWithCAS()
+		state.remoteStore = sharedRemote
+
+		pending := domain.DeviceEnrollmentRequest{
+			SchemaVersion:       1,
+			AccountID:           state.session.AccountID,
+			DeviceID:            "dev-web-010",
+			Label:               "Safe Web dev-web-010",
+			DeviceType:          "web",
+			EncryptionPublicKey: base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{1}, 32)),
+			RequestedAt:         "2026-04-06T15:00:00Z",
+		}
+		approved := domain.DeviceEnrollmentRequest{
+			SchemaVersion:       1,
+			AccountID:           state.session.AccountID,
+			DeviceID:            "dev-web-011",
+			Label:               "Safe Web dev-web-011",
+			DeviceType:          "web",
+			EncryptionPublicKey: base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{2}, 32)),
+			RequestedAt:         "2026-04-06T15:05:00Z",
+		}
+		if _, err := storage.StoreEnrollmentRequest(sharedRemote, pending); err != nil {
+			t.Fatalf("store pending enrollment request: %v", err)
+		}
+		if _, err := storage.StoreEnrollmentRequest(sharedRemote, approved); err != nil {
+			t.Fatalf("store approved enrollment request: %v", err)
+		}
+		if _, err := storage.StoreEnrollmentBundle(sharedRemote, domain.DeviceEnrollmentBundle{
+			SchemaVersion: 1,
+			AccountID:     state.session.AccountID,
+			DeviceID:      approved.DeviceID,
+			WrappedKey: domain.DeviceEnrollmentWrappedKey{
+				Algorithm:          "x25519-hkdf-aes-256-gcm",
+				EphemeralPublicKey: base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{3}, 32)),
+				Nonce:              base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{4}, 12)),
+				Ciphertext:         base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{5}, 48)),
+			},
+		}); err != nil {
+			t.Fatalf("store enrollment bundle: %v", err)
+		}
+
+		var output bytes.Buffer
+		if err := devicePending(&output, state, cliOptions{json: true}); err != nil {
+			t.Fatalf("device pending: %v", err)
+		}
+
+		var requests []domain.DeviceEnrollmentRequest
+		if err := json.Unmarshal(output.Bytes(), &requests); err != nil {
+			t.Fatalf("decode pending enrollment list: %v", err)
+		}
+		if len(requests) != 1 || requests[0].DeviceID != pending.DeviceID {
+			t.Fatalf("unexpected pending enrollment requests: %+v", requests)
+		}
+	})
+}
+
+func TestDeviceApproveStoresEnrollmentBundle(t *testing.T) {
+	withEmptyBootstrap(t, func(_ string) {
+		state, err := bootstrapCLIState()
+		if err != nil {
+			t.Fatalf("bootstrap state: %v", err)
+		}
+
+		sharedRemote := storage.NewMemoryObjectStoreWithCAS()
+		state.remoteStore = sharedRemote
+
+		requestKeyPair, err := safecrypto.GenerateDeviceKeyPair()
+		if err != nil {
+			t.Fatalf("generate request device key pair: %v", err)
+		}
+		request := domain.DeviceEnrollmentRequest{
+			SchemaVersion:       1,
+			AccountID:           state.session.AccountID,
+			DeviceID:            "dev-web-020",
+			Label:               "Safe Web dev-web-020",
+			DeviceType:          "web",
+			EncryptionPublicKey: base64.RawURLEncoding.EncodeToString(requestKeyPair.EncryptionPublicKey),
+			RequestedAt:         "2026-04-06T16:00:00Z",
+		}
+		if _, err := storage.StoreEnrollmentRequest(sharedRemote, request); err != nil {
+			t.Fatalf("store enrollment request: %v", err)
+		}
+
+		var output bytes.Buffer
+		if err := deviceApprove(&output, state, cliOptions{json: true}, request.DeviceID); err != nil {
+			t.Fatalf("device approve: %v", err)
+		}
+
+		var payload struct {
+			ApprovedDeviceID string `json:"approvedDeviceId"`
+			AccountID        string `json:"accountId"`
+			BundleAlgorithm  string `json:"bundleAlgorithm"`
+		}
+		if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+			t.Fatalf("decode approval payload: %v", err)
+		}
+		if payload.ApprovedDeviceID != request.DeviceID || payload.AccountID != request.AccountID {
+			t.Fatalf("unexpected approval payload: %+v", payload)
+		}
+
+		bundle, err := storage.LoadEnrollmentBundle(sharedRemote, request.AccountID, request.DeviceID)
+		if err != nil {
+			t.Fatalf("load enrollment bundle: %v", err)
+		}
+		amk, err := safecrypto.OpenDeviceEnrollmentBundle(
+			bundle,
+			request.DeviceID,
+			requestKeyPair.EncryptionPrivateKey,
+		)
+		if err != nil {
+			t.Fatalf("open enrollment bundle: %v", err)
+		}
+		if !bytes.Equal(amk, state.accountKey) {
+			t.Fatal("expected enrollment bundle to wrap the current account key")
 		}
 	})
 }

--- a/docs/project/HANDOFFS.md
+++ b/docs/project/HANDOFFS.md
@@ -53,6 +53,40 @@ Current planning issues:
 
 ## Entries
 
+### 2026-04-06 - Engineer1 progress note (W22)
+
+Task:
+
+- `W22 - Web sync and device management UX`
+
+Status:
+
+- in progress; refs #53
+
+Files touched:
+
+- `apps/web/src/server.ts`
+- `apps/web/test/client-surface.test.mjs`
+- `cmd/safe/main.go`
+- `cmd/safe/main_test.go`
+- `docs/project/WORKBOARD.md`
+- `docs/project/HANDOFFS.md`
+
+Outcome:
+
+- the web vault now surfaces sync push and pull actions against the existing CLI sync path, with explicit success or failure feedback rendered back into the unlocked vault surface
+- the web app now lists enrolled remote devices, shows pending enrollment requests, and can approve a pending request by invoking the merged enrollment bundle helper path
+- `cmd/safe` now exposes JSON-friendly `device list`, `device pending`, and `device approve <device-id>` commands so the web surface can reuse the shipped Go sync and enrollment logic instead of reimplementing it in TypeScript
+
+Verification:
+
+- `go test ./cmd/safe/...`
+- `pnpm --filter @safe/web test`
+
+Next action:
+
+- finish reviewing the W22 delta, then commit, push, and open the PR on issue `#53`
+
 ### 2026-04-06 - Engineer1 progress note (W21)
 
 Task:

--- a/docs/project/WORKBOARD.md
+++ b/docs/project/WORKBOARD.md
@@ -658,7 +658,7 @@ Owner:
 
 Status:
 
-- in progress (`refs #52`)
+- completed (`refs #52`)
 
 Write scope:
 
@@ -684,7 +684,7 @@ Owner:
 
 Status:
 
-- todo (`refs #53`)
+- in progress (`refs #53`)
 
 Write scope:
 


### PR DESCRIPTION
Implements W22 / #53 for the web sync and device-management surface.

## Changes
- add JSON-friendly `safe device list`, `safe device pending`, and `safe device approve <device-id>` commands so the web server can reuse the shipped Go sync and enrollment logic
- surface sync push or pull actions, enrolled-device visibility, pending enrollment requests, and approval controls in the unlocked web vault UI
- render explicit success or failure feedback for sync and approval actions in the web surface
- update W21/W22 execution state in the repo workboard and handoff log

## Verification
- go test ./cmd/safe/...
- pnpm --filter @safe/web test